### PR TITLE
Structual logging for front end backend

### DIFF
--- a/src/Wrido.Core/Logging/ILogger.cs
+++ b/src/Wrido.Core/Logging/ILogger.cs
@@ -1,0 +1,11 @@
+﻿using System;
+
+namespace Wrido.Core.Logging
+{
+  public interface ILogger
+  {
+    void Write(LogLevel level, Exception exception, string messageTemplate, params object[] propertyValues);
+    IDisposable BeginScope(string name, object value);
+    bool IsEnabled(LogLevel level);
+  }
+}

--- a/src/Wrido.Core/Logging/LogLevel.cs
+++ b/src/Wrido.Core/Logging/LogLevel.cs
@@ -1,0 +1,12 @@
+﻿namespace Wrido.Core.Logging
+{
+  public enum LogLevel
+  {
+    Verbose,
+    Debug,
+    Information,
+    Warning,
+    Error,
+    Critical
+  }
+}

--- a/src/Wrido.Core/Logging/LoggerExtensions.cs
+++ b/src/Wrido.Core/Logging/LoggerExtensions.cs
@@ -1,0 +1,43 @@
+﻿using System;
+
+namespace Wrido.Core.Logging
+{
+  public static class LoggerExtensions
+  {
+    public static void Verbose(this ILogger logger, string messageTemplate, params object[] propertyValues) =>
+      logger.Verbose(null, messageTemplate, propertyValues);
+
+    public static void Verbose(this ILogger logger, Exception exception, string messageTemplate, params object[] propertyValues) =>
+      logger.Write(LogLevel.Verbose, exception, messageTemplate, propertyValues);
+
+    public static void Debug(this ILogger logger, string messageTemplate, params object[] propertyValues) =>
+      logger.Debug(null, messageTemplate, propertyValues);
+
+    public static void Debug(this ILogger logger, Exception exception, string messageTemplate, params object[] propertyValues) =>
+      logger.Write(LogLevel.Debug, exception, messageTemplate, propertyValues);
+
+    public static void Information(this ILogger logger, string messageTemplate, params object[] propertyValues) =>
+      logger.Information(null, messageTemplate, propertyValues);
+
+    public static void Information(this ILogger logger, Exception exception, string messageTemplate, params object[] propertyValues) =>
+      logger.Write(LogLevel.Information, exception, messageTemplate, propertyValues);
+
+    public static void Warning(this ILogger logger, string messageTemplate, params object[] propertyValues) =>
+      logger.Warning(null, messageTemplate, propertyValues);
+
+    public static void Warning(this ILogger logger, Exception exception, string messageTemplate, params object[] propertyValues) =>
+      logger.Write(LogLevel.Warning, exception, messageTemplate, propertyValues);
+
+    public static void Error(this ILogger logger, string messageTemplate, params object[] propertyValues) =>
+      logger.Error(null, messageTemplate, propertyValues);
+
+    public static void Error(this ILogger logger, Exception exception, string messageTemplate, params object[] propertyValues) =>
+      logger.Write(LogLevel.Error, exception, messageTemplate, propertyValues);
+
+    public static void Critical(this ILogger logger, string messageTemplate, params object[] propertyValues) =>
+      logger.Critical(null, messageTemplate, propertyValues);
+
+    public static void Critical(this ILogger logger, Exception exception, string messageTemplate, params object[] propertyValues) =>
+      logger.Write(LogLevel.Critical, exception, messageTemplate, propertyValues);
+  }
+}

--- a/src/Wrido.Core/Logging/TimedOperation.cs
+++ b/src/Wrido.Core/Logging/TimedOperation.cs
@@ -1,0 +1,84 @@
+﻿using System;
+using System.Diagnostics;
+using System.Linq;
+
+namespace Wrido.Core.Logging
+{
+  public class TimedOperation : IDisposable
+  {
+    private readonly ILogger _logger;
+    private readonly string _messageTemplate;
+    private readonly object[] _propertyValues;
+    private readonly long _startTime;
+    private long _stopTime;
+    private readonly IDisposable _operationScope;
+
+    public bool IsCompleted { get; private set; }
+    public bool IsCancelled { get; private set; }
+    public LogLevel CompletionLevel { get; }
+    public LogLevel CancelledLevel { get; }
+    public Guid OperationId { get; }
+    public TimeSpan Elapsed => IsCompleted ? new TimeSpan(_stopTime - _startTime) : new TimeSpan(Stopwatch.GetTimestamp() - _startTime);
+
+    public TimedOperation(ILogger logger, string messageTemplate, object[] propertyValues, LogLevel completionLevel, LogLevel? cancelledLevel = null)
+    {
+      _logger = logger;
+      _messageTemplate = messageTemplate;
+      _propertyValues = propertyValues;
+      CompletionLevel = completionLevel;
+      CancelledLevel = cancelledLevel ?? completionLevel;
+      OperationId = Guid.NewGuid();
+      _operationScope = logger.BeginScope("operationId", OperationId);
+      _startTime = Stopwatch.GetTimestamp();
+    }
+
+    public void Cancel()
+    {
+      IsCancelled = true;
+      Stop();
+    }
+
+    public void Complete()
+    {
+      Stop();
+    }
+
+    public void Dispose()
+    {
+      if (IsCompleted)
+      {
+        return;
+      }
+      Stop();
+    }
+
+    private void Stop()
+    {
+      _stopTime = Stopwatch.GetTimestamp();
+      IsCompleted = true;
+      Write();
+      _operationScope.Dispose();
+    }
+
+    private void Write()
+    {
+      string outcome;
+      LogLevel logLevel;
+      if (IsCancelled)
+      {
+        outcome = "cancelled";
+        logLevel = CancelledLevel;
+      }
+      else
+      {
+        outcome = "completed";
+        logLevel = CompletionLevel;
+      }
+      var finalMsgTempalte = $"{_messageTemplate} {{outcome:l}} in {{elapsed:0.0}} ms.";
+      var finalPropertyValues = _propertyValues
+        .Concat(new object[] { outcome, Elapsed.TotalMilliseconds })
+        .ToArray();
+      _logger.Write(logLevel, null, finalMsgTempalte, finalPropertyValues);
+    }
+  }
+}

--- a/src/Wrido.Core/Logging/TimedOperationExtension.cs
+++ b/src/Wrido.Core/Logging/TimedOperationExtension.cs
@@ -1,0 +1,23 @@
+﻿namespace Wrido.Core.Logging
+{
+  public static class TimedOperationExtensions
+  {
+    public static TimedOperation Timed(this ILogger logger, string messageTemplate,
+        params object[] propertyValues)
+    {
+      return logger.Timed(LogLevel.Information, messageTemplate, propertyValues);
+    }
+
+    public static TimedOperation Timed(this ILogger logger, LogLevel level, string messageTemplate,
+        params object[] propertyValues)
+    {
+      return logger.Timed(level, level, messageTemplate, propertyValues);
+    }
+
+    public static TimedOperation Timed(this ILogger logger, LogLevel completionLevel, LogLevel cancelledLevel, string messageTemplate,
+        params object[] propertyValues)
+    {
+      return new TimedOperation(logger, messageTemplate, propertyValues, completionLevel, cancelledLevel);
+    }
+  }
+}

--- a/src/Wrido/InputHub.cs
+++ b/src/Wrido/InputHub.cs
@@ -1,17 +1,17 @@
-﻿using System;
-using System.Linq;
-using System.Threading;
-using System.Threading.Tasks;
+﻿using System.Threading.Tasks;
 using Microsoft.AspNetCore.SignalR;
-using Wrido.Core;
-using Wrido.Messages;
+using Serilog;
+using Wrido.Core.Logging;
+using Wrido.Logging;
 using Wrido.Services;
+using ILogger = Wrido.Core.Logging.ILogger;
 
 namespace Wrido
 {
   public class InputHub : Hub
   {
     private readonly IQueryService _queryService;
+    private readonly ILogger _logger = new SerilogLogger(Log.ForContext<InputHub>());
 
     public InputHub(IQueryService queryService)
     {
@@ -20,8 +20,11 @@ namespace Wrido
 
     public async Task QueryAsync(string rawQuery)
     {
-      var caller = Clients.Client(Context.ConnectionId);
-      await _queryService.QueryAsync(caller, rawQuery);
+      using (_logger.Timed("Query {rawQuery}", rawQuery))
+      {
+        var caller = Clients.Client(Context.ConnectionId);
+        await _queryService.QueryAsync(caller, rawQuery);
+      }
     }
   }
 }

--- a/src/Wrido/Logging/LogLevelExtensions.cs
+++ b/src/Wrido/Logging/LogLevelExtensions.cs
@@ -1,0 +1,30 @@
+﻿using System;
+using Serilog.Events;
+using Wrido.Core.Logging;
+
+namespace Wrido.Logging
+{
+  public static class LogLevelExtensions
+  {
+    public static LogEventLevel AsSerilogLevel(this LogLevel level)
+    {
+      switch (level)
+      {
+        case LogLevel.Verbose:
+          return LogEventLevel.Verbose;
+        case LogLevel.Debug:
+          return LogEventLevel.Debug;
+        case LogLevel.Information:
+          return LogEventLevel.Information;
+        case LogLevel.Warning:
+          return LogEventLevel.Warning;
+        case LogLevel.Error:
+          return LogEventLevel.Error;
+        case LogLevel.Critical:
+          return LogEventLevel.Fatal;
+        default:
+          throw new ArgumentOutOfRangeException(nameof(level), level, null);
+      }
+    }
+  }
+}

--- a/src/Wrido/Logging/LogProperties.cs
+++ b/src/Wrido/Logging/LogProperties.cs
@@ -1,0 +1,7 @@
+﻿namespace Wrido.Logging
+{
+  public class LogProperties
+  {
+    public const string QueryId = "queryId";
+  }
+}

--- a/src/Wrido/Logging/LogTemplates.cs
+++ b/src/Wrido/Logging/LogTemplates.cs
@@ -1,0 +1,8 @@
+﻿
+namespace Wrido.Logging
+{
+  public class LogTemplates
+  {
+    public const string Console = "[{Timestamp:HH:mm:ss}][{Level}] {Message:lj} {Properties}{NewLine}{Exception}";
+  }
+}

--- a/src/Wrido/Logging/LoggingHub.cs
+++ b/src/Wrido/Logging/LoggingHub.cs
@@ -1,0 +1,35 @@
+﻿using System;
+using System.Collections.Concurrent;
+using Microsoft.AspNetCore.SignalR;
+using Serilog;
+using Serilog.Core.Enrichers;
+using Wrido.Core.Logging;
+using ILogger = Serilog.ILogger;
+
+namespace Wrido.Logging
+{
+  public class LoggingHub : Hub
+  {
+    private static readonly ILogger _fallbackLogger = Log.ForContext<LoggingHub>();
+    private static readonly ConcurrentStack<ILogger> _loggerStack = new ConcurrentStack<ILogger>();
+
+    public void Write(LogLevel level, string messageTemplate, object[] propertyValues)
+    {
+      var logger = _loggerStack.TryPeek(out var currentLogger) ? currentLogger : _fallbackLogger;
+      logger.Write(level.AsSerilogLevel(), (Exception)null, messageTemplate, propertyValues);
+    }
+
+    public void BeginScope(string name, object value)
+    {
+      var propEnricher = new PropertyEnricher(name, value);
+      _loggerStack.Push(_loggerStack.TryPeek(out var recentLogger)
+        ? recentLogger.ForContext(propEnricher)
+        : Log.ForContext(propEnricher));
+    }
+
+    public void EndScope()
+    {
+      _loggerStack.TryPop(out _);
+    }
+  }
+}

--- a/src/Wrido/Logging/LoggingModule.cs
+++ b/src/Wrido/Logging/LoggingModule.cs
@@ -1,0 +1,27 @@
+﻿using System.Linq;
+using Autofac;
+using Autofac.Core;
+using Serilog;
+using ILogger = Wrido.Core.Logging.ILogger;
+
+namespace Wrido.Logging
+{
+  public class LoggingModule : Module
+  {
+    protected override void AttachToComponentRegistration(IComponentRegistry componentRegistry, IComponentRegistration registration)
+    {
+      // Ignore components that provide loggers
+      if (registration.Services.OfType<TypedService>().Any(ts => ts.ServiceType == typeof(ILogger)))
+      {
+        return;
+      }
+
+      registration.Preparing += (sender, args) =>
+      {
+        var serilogLogger = Log.ForContext(registration.Activator.LimitType);
+        ILogger wridoLogger = new SerilogLogger(serilogLogger);
+        args.Parameters = new[] { TypedParameter.From(wridoLogger) }.Concat(args.Parameters);
+      };
+    }
+  }
+}

--- a/src/Wrido/Logging/SerilogLogger.cs
+++ b/src/Wrido/Logging/SerilogLogger.cs
@@ -1,0 +1,31 @@
+﻿using System;
+using Serilog.Context;
+using Wrido.Core.Logging;
+
+namespace Wrido.Logging
+{
+  public class SerilogLogger : ILogger
+  {
+    private readonly Serilog.ILogger _logger;
+
+    public SerilogLogger(Serilog.ILogger logger)
+    {
+      _logger = logger;
+    }
+
+    public void Write(LogLevel level, Exception exception, string messageTemplate, params object[] propertyValues)
+    {
+      _logger.Write(level.AsSerilogLevel(), exception, messageTemplate, propertyValues);
+    }
+
+    public IDisposable BeginScope(string name, object value)
+    {
+      return LogContext.PushProperty(name, value);
+    }
+
+    public bool IsEnabled(LogLevel level)
+    {
+      return _logger.IsEnabled(level.AsSerilogLevel());
+    }
+  }
+}

--- a/src/Wrido/Services/QueryService.cs
+++ b/src/Wrido/Services/QueryService.cs
@@ -1,9 +1,12 @@
-﻿using System.Collections.Generic;
+﻿using System;
+using System.Collections.Generic;
 using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
 using Microsoft.AspNetCore.SignalR;
 using Wrido.Core;
+using Wrido.Core.Logging;
+using Wrido.Logging;
 using Wrido.Messages;
 using IQueryProvider = Wrido.Core.IQueryProvider;
 
@@ -17,50 +20,77 @@ namespace Wrido.Services
   public class QueryService : IQueryService
   {
     private readonly IEnumerable<IQueryProvider> _queryProviders;
+    private readonly ILogger _logger;
     private CancellationTokenSource _currentQuery;
 
-    public QueryService(IEnumerable<IQueryProvider> queryProviders)
+    public QueryService(IEnumerable<IQueryProvider> queryProviders, ILogger logger)
     {
       _queryProviders = queryProviders;
+      _logger = logger;
     }
 
     public async Task QueryAsync(IClientProxy caller, string rawQuery)
     {
-      // Cancel ongoing query
-      var currentQuery = new CancellationTokenSource();
-      var oldQuery = Interlocked.Exchange(ref _currentQuery, currentQuery);
-      oldQuery?.Cancel();
-      var ct = currentQuery.Token;
+      CancelOngoingQuery(out var currentCt);
 
-      // Notify about received query
       var query = new Query(rawQuery);
-      await caller.InvokeAsync(new QueryReceived(query), ct);
+      using (_logger.BeginScope(LogProperties.QueryId, query.Id))
+      {
+        _logger.Verbose("Notifying frontend that query is received.");
+        await caller.InvokeAsync(new QueryReceived(query), currentCt);
 
-      // Notify about number of providers
-      var providers = GetProviders(query);
-      await caller.InvokeAsync(QueryExecuting.By(providers), ct);
+        var providers = GetProviders(query);
+        _logger.Verbose("Notifying frontend that query will be handled by {providerCount} providers.", providers.Count);
+        await caller.InvokeAsync(QueryExecuting.By(providers), currentCt);
 
-      // Execute query
-      var allTasks = providers
-        .Select(p => Task.Run(async () =>
-        {
-          var results = await p.QueryAsync(query, ct);
-          await caller.InvokeAsync(new ResultsAvailable(query.Id, results), ct);
-          return results;
-        }, ct))
-        .ToList();
+        // Execute query
+        var allTasks = providers
+          .Select(p => Task.Run(async () =>
+          {
+            var providerName = p.GetType().Name;
+            using (var operation = _logger.Timed("Query from {queryProvider}", providerName))
+            {
+              try
+              {
+                var results = await p.QueryAsync(query, currentCt);
+                currentCt.ThrowIfCancellationRequested();
+                _logger.Debug("Provider {queryProvider} executed query successfully. {resultCount} results available.", providerName, results.Count);
+                await caller.InvokeAsync(new ResultsAvailable(query.Id, results), currentCt);
+                return results;
+              }
+              catch (Exception)
+              {
+                operation.Cancel();
+                throw;
+              }
+            }
+          }, currentCt))
+          .ToList();
 
-      await Task.WhenAll(allTasks);
-      var allResults = allTasks.Where(t => t.IsCompleted).SelectMany(t => t.Result).ToList();
-      await caller.InvokeAsync(new QueryCompleted(query.Id, allResults), ct);
+        Task.WaitAll(allTasks.ToArray<Task>());
+        var allResults = allTasks.Where(t => t.IsCompleted).SelectMany(t => t.Result).ToList();
+        _logger.Verbose("Query completed. Total result count is {resultCount}", allResults.Count);
+        await caller.InvokeAsync(new QueryCompleted(query.Id, allResults), currentCt);
+      }
     }
 
-    public IList<IQueryProvider> GetProviders(Query query)
+    private IList<IQueryProvider> GetProviders(Query query)
     {
       return _queryProviders
         .Where(q => q.CanHandle(query))
         .ToList()
         .AsReadOnly();
+    }
+
+    private void CancelOngoingQuery(out CancellationToken nextToken)
+    {
+      var currentQuery = new CancellationTokenSource();
+      nextToken = currentQuery.Token;
+      using (_logger.Timed(LogLevel.Debug, "Cancel ongoing query"))
+      {
+        var oldQuery = Interlocked.Exchange(ref _currentQuery, currentQuery);
+        oldQuery?.Cancel();
+      }
     }
   }
 }

--- a/src/Wrido/Startup.cs
+++ b/src/Wrido/Startup.cs
@@ -6,6 +6,7 @@ using Microsoft.Extensions.DependencyInjection;
 using Newtonsoft.Json;
 using Newtonsoft.Json.Serialization;
 using Wrido.Core.Resolution;
+using Wrido.Logging;
 using Wrido.Services;
 
 namespace Wrido
@@ -31,8 +32,14 @@ namespace Wrido
 
     public void ConfigureContainer(ContainerBuilder builder)
     {
-      builder.RegisterModule(new DummyQueryModule());
-      builder.RegisterType<QueryService>().AsImplementedInterfaces().SingleInstance();
+      builder
+        .RegisterModule<DummyQueryModule>()
+        .RegisterModule<LoggingModule>();
+
+      builder
+        .RegisterType<QueryService>()
+        .AsImplementedInterfaces()
+        .SingleInstance();
     }
 
     public void Configure(IApplicationBuilder app, IHostingEnvironment env)
@@ -41,7 +48,11 @@ namespace Wrido
         .UseDeveloperExceptionPage()
         .UseDefaultFiles()
         .UseStaticFiles()
-        .UseSignalR(hub => hub.MapHub<InputHub>("input"))
+        .UseSignalR(hub =>
+          {
+            hub.MapHub<InputHub>("input");
+            hub.MapHub<LoggingHub>("logging");
+          })
         .UseMvc();
     }
   }

--- a/src/Wrido/Wrido.csproj
+++ b/src/Wrido/Wrido.csproj
@@ -17,6 +17,8 @@
     <PackageReference Include="electronnet.api" Version="0.0.7" />
     <PackageReference Include="Microsoft.AspNetCore.All" Version="2.0.5" />
     <PackageReference Include="Microsoft.AspNetCore.SignalR" Version="1.0.0-alpha2-final" />
+    <PackageReference Include="Serilog.AspNetCore" Version="2.1.0" />
+    <PackageReference Include="Serilog.Sinks.Console" Version="3.1.1" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/Wrido/wwwroot/index.htm
+++ b/src/Wrido/wwwroot/index.htm
@@ -12,5 +12,6 @@
     <ul id="wrido-result"></ul>
     <script type="text/javascript" src="/script/signalr-client-1.0.0-alpha2-final.js"></script>
     <script type="text/javascript" src="/script/index.js"></script>
+    <script type="text/javascript" src="/script/logging.js"></script>
 </body>
 </html>

--- a/src/Wrido/wwwroot/script/logging.js
+++ b/src/Wrido/wwwroot/script/logging.js
@@ -1,0 +1,30 @@
+﻿let logger = new signalR.HubConnection('/logging');
+
+// Available Log levels
+const verbose = 'Verbose';
+const debug = 'Debug';
+const information = 'Information';
+const warning = 'Warning';
+const error = 'Error';
+const critical = 'Critical';
+
+// Begins a logging scope with name and value matching
+// provided arguments. A logging scope will enrich
+// log entries with the property.
+const beginScope = 'BeginScope';
+
+// Ends the latest scope and thereby removes the
+// latest added property.
+const endScope = 'EndScope';
+
+// Performs a write operation.
+// Arguments: logLevel, messageTemplate, propertyValues
+const write = 'Write';
+
+logger.start().then(() => {
+    logger.invoke(beginScope, 'scopeName', 'scopeValue').then(() => {
+        logger.invoke(write, information, "front end started at {renderTime}", [new Date()]);
+        logger.invoke(write, information, "it turns out that {first} plus {second} is {sum}", [1, 2, 1+2]);
+        logger.invoke(endScope);
+    });
+});


### PR DESCRIPTION
This PR adds logging capabilities to the backend by using `Serilog` and to the frontend by exposing a logging hub that supports scopes and writes.

```js
    logger.invoke(beginScope, 'scopeName', 'scopeValue').then(() => {
        logger.invoke(write, information, "front end started at {renderTime}", [new Date()]);
        logger.invoke(write, information, "it turns out that {first} plus {second} is {sum}", [1, 2, 1+2]);
        logger.invoke(endScope);
}
```

![image](https://user-images.githubusercontent.com/1032755/35185819-4f2919e0-fe0a-11e7-878a-5ebdd8b29230.png)
