### PR TITLE
Add support for dynamic plugin loading

### DIFF
--- a/src/Wrido.Core.Tests/Wrido.Core.Tests.csproj
+++ b/src/Wrido.Core.Tests/Wrido.Core.Tests.csproj
@@ -17,4 +17,8 @@
     <ProjectReference Include="..\Wrido.Core\Wrido.Core.csproj" />
   </ItemGroup>
 
+  <ItemGroup>
+    <Folder Include="Configuration\" />
+  </ItemGroup>
+
 </Project>

--- a/src/Wrido.Core/Configuration/AppConfiguration.cs
+++ b/src/Wrido.Core/Configuration/AppConfiguration.cs
@@ -5,7 +5,7 @@
     string HotKey { get; }
   }
 
-  public class AppConfiguration : IAppConfiguration
+  internal class AppConfiguration : IAppConfiguration
   {
     public string HotKey { get; set; }
   }

--- a/src/Wrido.Core/Configuration/ConfigurationProvider.cs
+++ b/src/Wrido.Core/Configuration/ConfigurationProvider.cs
@@ -1,18 +1,143 @@
-﻿namespace Wrido.Configuration
+﻿using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Threading;
+using System.Threading.Tasks;
+using Newtonsoft.Json.Linq;
+using Wrido.Logging;
+
+namespace Wrido.Configuration
 {
   public interface IConfigurationProvider
   {
+    Task ReloadAsync(CancellationToken ct = default);
     IAppConfiguration GetAppConfiguration();
+    bool TryGetConfiguration<TPlugin>(string pluginName, out TPlugin pluginConfig) where TPlugin : IPluginConfiguration;
+    IEnumerable<string> GetPluginNames();
   }
 
   public class ConfigurationProvider : IConfigurationProvider
   {
-    public IAppConfiguration GetAppConfiguration()
+    private readonly ILogger _logger;
+    private readonly string _wridoFolder;
+    private readonly string _wridoCfgFile;
+    private AppConfiguration _appConfig;
+    private IDictionary<string, JToken> _plugins;
+
+    public ConfigurationProvider(ILogger logger)
     {
-      return new AppConfiguration
-      {
-        HotKey = "CommandOrControl+X"
-      };
+      _logger = logger;
+      _wridoFolder = $"{Environment.GetFolderPath(Environment.SpecialFolder.UserProfile)}\\.wrido";
+      _wridoCfgFile = $"{_wridoFolder}\\wrido.json";
+      _plugins = new Dictionary<string, JToken>();
+
+      LoadConfiguration();
     }
+
+    public Task ReloadAsync(CancellationToken ct = default)
+    {
+      LoadConfiguration();
+      return Task.CompletedTask;
+    }
+
+    private void LoadConfiguration()
+    {
+      var cfgOperation = _logger.Timed("Load application configuration");
+
+      if (!File.Exists(_wridoCfgFile))
+      {
+        _logger.Information("No config file found at {configPath}. Will default to fallback configuration", _wridoCfgFile);
+        _appConfig = new AppConfiguration
+        {
+          HotKey = "CommandOrControl+X"
+        };
+        _plugins = new Dictionary<string, JToken>
+        {
+          {"Wrido.Plugin.StackExchange", new JValue("Wrido.Plugin.StackExchange")},
+          {"Wrido.Plugin.Google", new JValue("Wrido.Plugin.Google")},
+          {"Wrido.Plugin.Dummy", new JValue("Wrido.Plugin.Dummy")}
+        };
+        cfgOperation.Cancel();
+        return;
+      }
+
+      try
+      {
+        var cfgJson = File.ReadAllText(_wridoCfgFile);
+        var dynamicConfig = JObject.Parse(cfgJson);
+        _appConfig = dynamicConfig.ToObject<AppConfiguration>();
+
+        var plugins = dynamicConfig.GetValue("plugins", StringComparison.OrdinalIgnoreCase);
+        if (plugins == null)
+        {
+          _logger.Information("Configuration does not contain a 'plugin' section.");
+          return;
+        }
+        if (plugins.Type != JTokenType.Array)
+        {
+          _logger.Warning("Expected plugin configuration to be array, but received {tokenType}", plugins.Type);
+          cfgOperation.Cancel();
+          return;
+        }
+        var pluginsArray = plugins as JArray;
+        _plugins = new Dictionary<string, JToken>();
+        _logger.Information("{pluginCount} plugin entries in configuration", pluginsArray?.Count ?? 0);
+        foreach (var plugin in pluginsArray ?? Enumerable.Empty<JToken>())
+        {
+          if (plugin.Type == JTokenType.String)
+          {
+            _plugins.Add(plugin.Value<string>(), plugin);
+            continue;
+          }
+          if (plugin.Type == JTokenType.Object)
+          {
+            var pluginObj = plugin.Value<JObject>();
+            var nameToken = pluginObj.GetValue("Name", StringComparison.OrdinalIgnoreCase);
+            if (nameToken == null)
+            {
+              _logger.Warning("Expected plugin object to have property 'name'.");
+              continue;
+            }
+            if (nameToken.Type != JTokenType.String)
+            {
+              _logger.Warning("Expected plugin name to be a string, but got {tokenType}", nameToken.Type);
+              continue;
+            }
+            _plugins.Add(nameToken.Value<string>(), nameToken);
+          }
+          _logger.Warning("Unidentified plugin of type {tokenType}", plugin.Type);
+        }
+        cfgOperation.Complete();
+      }
+      catch (Exception e)
+      {
+        _logger.Warning(e, "An exception was thrown while deserializing the configuration.");
+        cfgOperation.Cancel();
+      }
+    }
+
+    public IAppConfiguration GetAppConfiguration() => _appConfig;
+
+    public bool TryGetConfiguration<TPlugin>(string pluginName, out TPlugin pluginConfig) where TPlugin : IPluginConfiguration
+    {
+      pluginConfig = default;
+      if (!_plugins.ContainsKey(pluginName))
+      {
+        return false;
+      }
+      try
+      {
+        pluginConfig = _plugins[pluginName].Value<TPlugin>();
+        return true;
+      }
+      catch (Exception e)
+      {
+        _logger.Information(e, "Unable to extract {pluginName} configuration as a {pluginType}", pluginName, typeof(TPlugin).Name);
+        return false;
+      }
+    }
+
+    public IEnumerable<string> GetPluginNames() => _plugins.Keys;
   }
 }

--- a/src/Wrido.Core/Configuration/IPluginConfiguration.cs
+++ b/src/Wrido.Core/Configuration/IPluginConfiguration.cs
@@ -1,0 +1,7 @@
+﻿namespace Wrido.Configuration
+{
+  public interface IPluginConfiguration
+  {
+    string Keyword { get; }
+  }
+}

--- a/src/Wrido.Core/Plugin/IWridoPlugin.cs
+++ b/src/Wrido.Core/Plugin/IWridoPlugin.cs
@@ -1,4 +1,5 @@
 ﻿using Autofac;
+using Autofac.Core;
 
 namespace Wrido.Plugin
 {

--- a/src/Wrido.Core/Wrido.Core.csproj
+++ b/src/Wrido.Core/Wrido.Core.csproj
@@ -8,6 +8,7 @@
 
   <ItemGroup>
     <PackageReference Include="Autofac" Version="4.6.2" />
+    <PackageReference Include="Newtonsoft.Json" Version="10.0.3" />
   </ItemGroup>
 
 </Project>

--- a/src/Wrido.Plugin.StackExchange/AskUbuntu/AskUbuntuProvider.cs
+++ b/src/Wrido.Plugin.StackExchange/AskUbuntu/AskUbuntuProvider.cs
@@ -1,6 +1,5 @@
 ﻿using System;
 using System.Collections.Generic;
-using Wrido.Core.Queries;
 using Wrido.Plugin.StackExchange.Common;
 using Wrido.Queries;
 

--- a/src/Wrido.Plugin.StackExchange/StackExchangePlugin.cs
+++ b/src/Wrido.Plugin.StackExchange/StackExchangePlugin.cs
@@ -6,6 +6,7 @@ using Autofac;
 using Autofac.Core;
 using Newtonsoft.Json;
 using Newtonsoft.Json.Serialization;
+using Wrido.Configuration;
 using Wrido.Core.Queries;
 using Wrido.Plugin.StackExchange.AskUbuntu;
 using Wrido.Plugin.StackExchange.Common;

--- a/src/Wrido/Logging/LoggingModule.cs
+++ b/src/Wrido/Logging/LoggingModule.cs
@@ -2,7 +2,6 @@
 using Autofac;
 using Autofac.Core;
 using Serilog;
-using ILogger = Wrido.Logging.ILogger;
 
 namespace Wrido.Logging
 {

--- a/src/Wrido/Plugin/AssemblyPluginLoader.cs
+++ b/src/Wrido/Plugin/AssemblyPluginLoader.cs
@@ -1,0 +1,68 @@
+﻿using System;
+using System.IO;
+using System.Linq;
+using System.Reflection;
+using Wrido.Logging;
+
+namespace Wrido.Plugin
+{
+  public interface IPluginLoader
+  {
+    bool TryLoad(string pluginName, out IWridoPlugin plugin);
+  }
+
+  public class AssemblyPluginLoader : IPluginLoader
+  {
+    private readonly string _currentDirectory;
+    private readonly ILogger _logger;
+
+    public AssemblyPluginLoader(ILogger logger)
+    {
+      _logger = logger;
+      _currentDirectory = AppDomain.CurrentDomain.BaseDirectory;
+    }
+
+    public bool TryLoad(string pluginName, out IWridoPlugin plugin)
+    {
+      plugin = default;
+
+      var assemblyFiles = Directory
+        .GetFiles(_currentDirectory)
+        .Where(f => f.EndsWith(".dll", StringComparison.OrdinalIgnoreCase));
+
+      var exactMatch = assemblyFiles.FirstOrDefault(f => f.EndsWith($"{pluginName}.dll", StringComparison.InvariantCultureIgnoreCase));
+      if (exactMatch == null)
+      {
+        return false;
+      }
+
+      try
+      {
+        var pluginAssembly = Assembly.LoadFile(exactMatch);
+        var pluginTypes = pluginAssembly.DefinedTypes
+          .Where(t => t.ImplementedInterfaces.Contains(typeof(IWridoPlugin)))
+          .Where(t => t.GetConstructors().Any(c => !c.GetParameters().Any()))
+          .ToList();
+
+        if (pluginTypes.Count == 0)
+        {
+          _logger.Debug("Assembly {assemblyName} did not contain any matching wrido plugins", pluginAssembly.FullName);
+          return false;
+        }
+        if (pluginTypes.Count != 1)
+        {
+          _logger.Warning("Assembly {assemblyName} contains {pluginCount} plugins. Only one will be loaded. ", pluginAssembly.FullName, pluginTypes.Count);
+        }
+        var pluginType = pluginTypes.First();
+        _logger.Information("Preparing to load plugin {pluginName} of type {pluginType} found in {pluginAssembly}", pluginName, pluginType, pluginAssembly.FullName);
+        plugin = (IWridoPlugin) Activator.CreateInstance(pluginType);
+        return true;
+      }
+      catch (Exception e)
+      {
+        _logger.Warning(e, "Something went wrong when trying to create plugin {pluginName}", pluginName);
+        return false;
+      }
+    }
+  }
+}

--- a/src/Wrido/Plugin/ComponentContextPluginExtension.cs
+++ b/src/Wrido/Plugin/ComponentContextPluginExtension.cs
@@ -1,0 +1,18 @@
+﻿using System.Collections.Generic;
+using Autofac;
+using Autofac.Core;
+
+namespace Wrido.Plugin
+{
+  public static class ComponentContextPluginExtension
+  {
+    public static IEnumerable<TService> ResolvePluginServices<TService>(this IComponentContext context)
+    {
+      if (!context.IsRegistered<PluginServiceProvider>())
+      {
+        throw new DependencyResolutionException("Unable to resolve plugins without PluginServiceProvider registered");
+      }
+      return context.Resolve<PluginServiceProvider>().GetServices<TService>();
+    }
+  }
+}

--- a/src/Wrido/Plugin/PluginModule.cs
+++ b/src/Wrido/Plugin/PluginModule.cs
@@ -1,0 +1,30 @@
+﻿using Autofac;
+using Wrido.Queries;
+using Wrido.Resources;
+
+namespace Wrido.Plugin
+{
+  public class  PluginModule : Module
+  {
+    protected override void Load(ContainerBuilder builder)
+    {
+      builder
+        .RegisterType<AssemblyPluginLoader>()
+        .AsImplementedInterfaces()
+        .SingleInstance();
+
+      builder
+        .RegisterType<PluginServiceProvider>()
+        .AsSelf()
+        .SingleInstance();
+
+      builder
+        .Register(c => c.ResolvePluginServices<IQueryProvider>())
+        .InstancePerDependency();
+
+      builder
+        .Register(c => c.ResolvePluginServices<EmbeddedResource>())
+        .InstancePerDependency();
+    }
+  }
+}

--- a/src/Wrido/Plugin/PluginServiceProvider.cs
+++ b/src/Wrido/Plugin/PluginServiceProvider.cs
@@ -1,0 +1,92 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using Autofac;
+using Wrido.Configuration;
+using Wrido.Logging;
+
+namespace Wrido.Plugin
+{
+  public class PluginServiceProvider : IDisposable
+  {
+    private readonly IConfigurationProvider _configurationProvider;
+    private readonly ILogger _logger;
+    private readonly List<IPluginLoader> _pluginLoaders;
+    private readonly IContainer _rootPluginContainer;
+    private readonly IList<ILifetimeScope> _pluginScopes;
+
+    public PluginServiceProvider(IConfigurationProvider configurationProvider, IEnumerable<IPluginLoader> pluginLoaders, ILogger logger)
+    {
+      _pluginScopes = new List<ILifetimeScope>();
+      _configurationProvider = configurationProvider;
+      _logger = logger;
+      _pluginLoaders = pluginLoaders.ToList();
+      _rootPluginContainer = CreatePluginContainer();
+      CreatePluginLifetimeScopes();
+    }
+
+    public IContainer CreatePluginContainer()
+    {
+      _logger.Verbose("Creating Plugin container.");
+      var builder = new ContainerBuilder();
+
+      builder
+        .RegisterModule<ConfigurationModule>();
+
+      return builder.Build();
+    }
+
+    private void CreatePluginLifetimeScopes()
+    {
+      using (_logger.Timed("Creating lifetime scopes for plugins"))
+      {
+        foreach (var pluginScope in _pluginScopes)
+        {
+          _logger.Verbose("Disposing lifetime scope for {pluginName}", pluginScope.Tag);
+          pluginScope.Dispose();
+        }
+
+        var pluginNames = _configurationProvider.GetPluginNames();
+        foreach (var pluginName in pluginNames)
+        {
+          _logger.Debug("Preparing to load plugin {pluginName}", pluginName);
+          foreach (var pluginLoader in _pluginLoaders)
+          {
+            if (pluginLoader.TryLoad(pluginName, out var plugin))
+            {
+              _logger.Information("Successfully loaded plugin {pluginName} using {pluginLoader}", pluginName, pluginLoader.GetType().Name);
+              _pluginScopes.Add(_rootPluginContainer.BeginLifetimeScope(pluginName, b =>
+              {
+                plugin.Register(b);
+                b.RegisterModule<LoggingModule>();
+              }));
+              break;
+            }
+            _logger.Verbose("The plugin loader {pluginLoader} was unable to load {pluginName}", pluginLoader.GetType().Name, pluginName);
+          }
+        }
+      }
+    }
+
+    public IEnumerable<TService> GetServices<TService>()
+    {
+      foreach (var pluginScope in _pluginScopes)
+      {
+        var pluginServices = pluginScope.Resolve<IEnumerable<TService>>();
+        foreach (var service in pluginServices)
+        {
+          yield return service;
+        }
+      }
+    }
+
+    public void Dispose()
+    {
+      foreach (var pluginScope in _pluginScopes)
+      {
+        pluginScope.Dispose();
+      }
+      _rootPluginContainer.Dispose();
+    }
+  }
+}

--- a/src/Wrido/Queries/QueryService.cs
+++ b/src/Wrido/Queries/QueryService.cs
@@ -4,10 +4,8 @@ using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
 using Microsoft.AspNetCore.SignalR;
-using Wrido.Core.Queries;
 using Wrido.Logging;
 using Wrido.Messages;
-using IQueryProvider = Wrido.Queries.IQueryProvider;
 
 namespace Wrido.Queries
 {
@@ -57,7 +55,7 @@ namespace Wrido.Queries
                 await caller.InvokeAsync(new ResultsAvailable(query.Id, results), currentCt);
                 return results;
               }
-              catch (Exception e)
+              catch (Exception)
               {
                 operation.Cancel();
                 throw;

--- a/src/Wrido/Startup.cs
+++ b/src/Wrido/Startup.cs
@@ -8,9 +8,7 @@ using Newtonsoft.Json.Serialization;
 using Wrido.Configuration;
 using Wrido.Electron;
 using Wrido.Logging;
-using Wrido.Plugin.Dummy;
-using Wrido.Plugin.Google;
-using Wrido.Plugin.StackExchange;
+using Wrido.Plugin;
 using Wrido.Queries;
 using Wrido.Resources;
 
@@ -43,6 +41,7 @@ namespace Wrido
         .RegisterModule<LoggingModule>()
         .RegisterModule<ConfigurationModule>()
         .RegisterModule<ResourceAspNetModule>()
+        .RegisterModule<PluginModule>()
         .RegisterModule<ElectronModule>();
 
       builder
@@ -54,10 +53,6 @@ namespace Wrido
         .RegisterType<ExecutionService>()
         .AsImplementedInterfaces()
         .SingleInstance();
-
-      new GooglePlugin().Register(builder);
-      new StackExchangePlugin().Register(builder);
-      new DummyPlugin().Register(builder);
     }
 
     public void Configure(IApplicationBuilder app, IHostingEnvironment env)

--- a/wrido.sln
+++ b/wrido.sln
@@ -18,7 +18,9 @@ Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Wrido.Plugin.StackExchange.
 EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Wrido.TestCommon", "src\Wrido.TestCommon\Wrido.TestCommon.csproj", "{68D10318-41FB-48A7-BDCC-B1B6808A3E0B}"
 EndProject
-Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Wrido.Plugin.Dummy", "src\Wrido.Plugin.Dummy\Wrido.Plugin.Dummy.csproj", "{15CD30AB-7394-4D6A-B690-80EEBCD1F471}"
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Wrido.Plugin.Dummy", "src\Wrido.Plugin.Dummy\Wrido.Plugin.Dummy.csproj", "{15CD30AB-7394-4D6A-B690-80EEBCD1F471}"
+EndProject
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Wrido.Core.Tests", "src\Wrido.Core.Tests\Wrido.Core.Tests.csproj", "{0C9C442D-0855-41D8-8E9B-31C15DA7C4B7}"
 EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
@@ -114,6 +116,18 @@ Global
 		{15CD30AB-7394-4D6A-B690-80EEBCD1F471}.Release|x64.Build.0 = Release|Any CPU
 		{15CD30AB-7394-4D6A-B690-80EEBCD1F471}.Release|x86.ActiveCfg = Release|Any CPU
 		{15CD30AB-7394-4D6A-B690-80EEBCD1F471}.Release|x86.Build.0 = Release|Any CPU
+		{0C9C442D-0855-41D8-8E9B-31C15DA7C4B7}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{0C9C442D-0855-41D8-8E9B-31C15DA7C4B7}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{0C9C442D-0855-41D8-8E9B-31C15DA7C4B7}.Debug|x64.ActiveCfg = Debug|Any CPU
+		{0C9C442D-0855-41D8-8E9B-31C15DA7C4B7}.Debug|x64.Build.0 = Debug|Any CPU
+		{0C9C442D-0855-41D8-8E9B-31C15DA7C4B7}.Debug|x86.ActiveCfg = Debug|Any CPU
+		{0C9C442D-0855-41D8-8E9B-31C15DA7C4B7}.Debug|x86.Build.0 = Debug|Any CPU
+		{0C9C442D-0855-41D8-8E9B-31C15DA7C4B7}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{0C9C442D-0855-41D8-8E9B-31C15DA7C4B7}.Release|Any CPU.Build.0 = Release|Any CPU
+		{0C9C442D-0855-41D8-8E9B-31C15DA7C4B7}.Release|x64.ActiveCfg = Release|Any CPU
+		{0C9C442D-0855-41D8-8E9B-31C15DA7C4B7}.Release|x64.Build.0 = Release|Any CPU
+		{0C9C442D-0855-41D8-8E9B-31C15DA7C4B7}.Release|x86.ActiveCfg = Release|Any CPU
+		{0C9C442D-0855-41D8-8E9B-31C15DA7C4B7}.Release|x86.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE
@@ -126,6 +140,7 @@ Global
 		{B8FD5F64-8FCD-400E-8AF7-B1048AD22C8A} = {5EDA50CA-C3D6-4320-AD14-56243B7058C2}
 		{68D10318-41FB-48A7-BDCC-B1B6808A3E0B} = {5EDA50CA-C3D6-4320-AD14-56243B7058C2}
 		{15CD30AB-7394-4D6A-B690-80EEBCD1F471} = {1B248AFD-69BC-4290-BB94-F63EA4A49513}
+		{0C9C442D-0855-41D8-8E9B-31C15DA7C4B7} = {5EDA50CA-C3D6-4320-AD14-56243B7058C2}
 	EndGlobalSection
 	GlobalSection(ExtensibilityGlobals) = postSolution
 		SolutionGuid = {0371E56C-FE2E-44B5-B4F3-21B72D3612F4}


### PR DESCRIPTION
This PR adds dynamic loading of plugins based on config. By default it looks for a `wrido.json` in a subfolder to the user profile (Windows: `%USERHOME%`, Mac (I assume): `~/`) named `wrido`.

Example of configuration file

```json
{
  "hotKey" : "alt+space",
  "plugins" : [
    "wrido.plugin.dummy",
    "wrido.plugin.google",
    {
      "name": "wrido.plugin.files",
      "include" : [
      
      ]
    }
  ]
}
```

`plugins` is an array that either take the name of the plugin or a complex object where `name` is mandatory in order to load the plugin. The object can contain other properties that can be deserialized by the plugin.

The plugins dependency injection container is sandboxed from the application container, meaning that it can only resolve services that are "acceptable" for a plugin to resolve and at the same time it can only register explicit services to the application container :tada: