### PR TITLE
Add 'icon' and 'renderer' property to query result

### DIFF
--- a/src/Wrido.Core/Queries/IQueryProvider.cs
+++ b/src/Wrido.Core/Queries/IQueryProvider.cs
@@ -1,7 +1,6 @@
 ﻿using System.Collections.Generic;
 using System.Threading;
 using System.Threading.Tasks;
-using Wrido.Core.Queries;
 
 namespace Wrido.Queries
 {

--- a/src/Wrido.Core/Queries/QueryResult.cs
+++ b/src/Wrido.Core/Queries/QueryResult.cs
@@ -1,12 +1,11 @@
-﻿using System.Collections.Generic;
-using Wrido.Resources;
+﻿using Wrido.Resources;
 
-namespace Wrido.Core.Queries
+namespace Wrido.Queries
 {
   public class QueryResult
   {
     public string Title { get; set; }
     public string Description { get; set; }
-    public IEnumerable<Resource> Resources { get; set; }
+    public ImageResource Image { get; set; }
   }
 }

--- a/src/Wrido.Core/Queries/QueryResult.cs
+++ b/src/Wrido.Core/Queries/QueryResult.cs
@@ -6,6 +6,7 @@ namespace Wrido.Queries
   {
     public string Title { get; set; }
     public string Description { get; set; }
-    public ImageResource Image { get; set; }
+    public Image Icon { get; set; }
+    public Script Renderer { get; set; }
   }
 }

--- a/src/Wrido.Core/Queries/WebResult.cs
+++ b/src/Wrido.Core/Queries/WebResult.cs
@@ -1,5 +1,4 @@
 ﻿using System.Diagnostics;
-using Wrido.Core.Queries;
 
 namespace Wrido.Queries
 {

--- a/src/Wrido.Core/Queries/WebResultExecuter.cs
+++ b/src/Wrido.Core/Queries/WebResultExecuter.cs
@@ -2,7 +2,6 @@
 using System.Runtime.InteropServices;
 using System.Threading;
 using System.Threading.Tasks;
-using Wrido.Core.Queries;
 
 namespace Wrido.Queries
 {

--- a/src/Wrido.Core/Resources/EmbeddedResource.cs
+++ b/src/Wrido.Core/Resources/EmbeddedResource.cs
@@ -1,31 +1,14 @@
-﻿using System;
-using System.Collections.Generic;
-using System.IO;
-
-namespace Wrido.Resources
+﻿namespace Wrido.Resources
 {
   public class EmbeddedResource
   {
     public byte[] Data { get; }
     public string ResourcePath { get; }
-    public string ContentType { get; }
-
-    private static readonly Dictionary<string, string> ContetTypes = new Dictionary<string, string>(StringComparer.InvariantCultureIgnoreCase)
-    {
-      {".png", "image/png"},
-      {".jpeg", "image/jpeg"},
-      {".gif", "image/gif"},
-    };
 
     public EmbeddedResource(string resourcePath, byte[] resourceData)
     {
       ResourcePath = resourcePath;
       Data = resourceData;
-      var fileExtension = Path.GetExtension(resourcePath);
-      if (ContetTypes.ContainsKey(fileExtension))
-      {
-        ContentType = ContetTypes[fileExtension];
-      }
     }
   }
 }

--- a/src/Wrido.Core/Resources/ModuleResourceExtension.cs
+++ b/src/Wrido.Core/Resources/ModuleResourceExtension.cs
@@ -13,6 +13,11 @@ namespace Wrido.Resources
       return builder.RegisterResources(typeof(TAssemblyType).Assembly);
     }
 
+    public static ContainerBuilder RegisterResources(this ContainerBuilder builder, object instanceFromAssembly)
+    {
+      return builder.RegisterResources(instanceFromAssembly.GetType().Assembly);
+    }
+
     public static ContainerBuilder RegisterResources(this ContainerBuilder builder, Assembly assembly)
     {
       var allResoures = assembly.GetManifestResourceNames();
@@ -21,12 +26,12 @@ namespace Wrido.Resources
       {
         var resourcePath = CreateResourcePath(resourceName);
 
-        using (var imageStream = assembly.GetManifestResourceStream(resourceName))
+        using (var resourceStream = assembly.GetManifestResourceStream(resourceName))
         using (var memoryStream = new MemoryStream())
         {
           try
           {
-            imageStream.CopyTo(memoryStream);
+            resourceStream.CopyTo(memoryStream);
             var resource = new EmbeddedResource(resourcePath, memoryStream.GetBuffer());
             builder
               .Register(c => resource)

--- a/src/Wrido.Core/Resources/Resource.cs
+++ b/src/Wrido.Core/Resources/Resource.cs
@@ -4,12 +4,24 @@ namespace Wrido.Resources
 {
   public abstract class Resource
   {
-    public string Key { get; set; }
   }
 
-  public sealed class ImageResource : Resource
+  public sealed class Image : Resource
   {
     public Uri Uri { get; set; }
     public string Alt { get; set; }
+  }
+
+  public sealed class Script : Resource
+  {
+    public Script(string uri)
+    {
+      if (Uri.TryCreate(uri, UriKind.RelativeOrAbsolute, out var parsed))
+      {
+        Uri = parsed;
+      }
+    }
+
+    public Uri Uri { get; set; }
   }
 }

--- a/src/Wrido.Core/Resources/ResourceKeys.cs
+++ b/src/Wrido.Core/Resources/ResourceKeys.cs
@@ -1,7 +1,0 @@
-﻿namespace Wrido.Resources
-{
-  public class ResourceKeys
-  {
-    public const string Icon = "Icon";
-  }
-}

--- a/src/Wrido.Plugin.Dummy/DummyPlugin.cs
+++ b/src/Wrido.Plugin.Dummy/DummyPlugin.cs
@@ -1,7 +1,6 @@
 ﻿using System;
 using Autofac;
 using Wrido.Queries;
-using Wrido.Resources;
 
 namespace Wrido.Plugin.Dummy
 {
@@ -21,12 +20,9 @@ namespace Wrido.Plugin.Dummy
         "Fast Provider",
         new Uri("/resources/wrido/plugin/dummy/resources/phone.png", UriKind.Relative));
 
-      builder.RegisterResources<DummyPlugin>();
-
       builder
         .RegisterInstance(slowProvider)
         .As<IQueryProvider>();
-
 
       builder
         .RegisterInstance(fastProvider)

--- a/src/Wrido.Plugin.Dummy/DummyPlugin.cs
+++ b/src/Wrido.Plugin.Dummy/DummyPlugin.cs
@@ -1,6 +1,5 @@
 ﻿using System;
 using Autofac;
-using Wrido.Core.Queries;
 using Wrido.Queries;
 using Wrido.Resources;
 

--- a/src/Wrido.Plugin.Dummy/DummyProvider.cs
+++ b/src/Wrido.Plugin.Dummy/DummyProvider.cs
@@ -2,7 +2,6 @@
 using System.Collections.Generic;
 using System.Threading;
 using System.Threading.Tasks;
-using Wrido.Core.Queries;
 using Wrido.Queries;
 using Wrido.Resources;
 
@@ -47,7 +46,7 @@ namespace Wrido.Plugin.Dummy
         {
           Title = $"[{_name}][{i}]: {query.Raw}",
           Description = $"Delayed with {duration.TotalMilliseconds} ms.",
-          Resources = new []{ _iconResource }
+          Image = _iconResource
         });
       }
 

--- a/src/Wrido.Plugin.Dummy/DummyProvider.cs
+++ b/src/Wrido.Plugin.Dummy/DummyProvider.cs
@@ -13,7 +13,7 @@ namespace Wrido.Plugin.Dummy
     private readonly TimeSpan _maxDuratin;
     private readonly string _name;
     private readonly Random _random;
-    private readonly ImageResource _iconResource;
+    private readonly Image _iconResource;
 
     public DummyProvider(TimeSpan minDuration, TimeSpan maxDuratin, string name, Uri iconUri)
     {
@@ -21,10 +21,9 @@ namespace Wrido.Plugin.Dummy
       _maxDuratin = maxDuratin;
       _name = name;
       _random = new Random();
-      _iconResource = new ImageResource
+      _iconResource = new Image
       {
         Alt = name,
-        Key = ResourceKeys.Icon,
         Uri = iconUri
       };
     }
@@ -46,7 +45,8 @@ namespace Wrido.Plugin.Dummy
         {
           Title = $"[{_name}][{i}]: {query.Raw}",
           Description = $"Delayed with {duration.TotalMilliseconds} ms.",
-          Image = _iconResource
+          Icon = _iconResource,
+          Renderer = new Script("/resources/wrido/plugin/dummy/resources/render.js")
         });
       }
 

--- a/src/Wrido.Plugin.Dummy/Resources/render.js
+++ b/src/Wrido.Plugin.Dummy/Resources/render.js
@@ -1,0 +1,1 @@
+﻿console.log('I render, therefor I am');

--- a/src/Wrido.Plugin.Dummy/Wrido.Plugin.Dummy.csproj
+++ b/src/Wrido.Plugin.Dummy/Wrido.Plugin.Dummy.csproj
@@ -7,11 +7,13 @@
   <ItemGroup>
     <None Remove="Resources\Banana.png" />
     <None Remove="Resources\Phone.png" />
+    <None Remove="Resources\render.js" />
   </ItemGroup>
 
   <ItemGroup>
     <EmbeddedResource Include="Resources\Banana.png" />
     <EmbeddedResource Include="Resources\Phone.png" />
+    <EmbeddedResource Include="Resources\render.js" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/Wrido.Plugin.Google/GooglePlugin.cs
+++ b/src/Wrido.Plugin.Google/GooglePlugin.cs
@@ -2,7 +2,6 @@
 using System.Net.Http;
 using Autofac;
 using Autofac.Core;
-using Wrido.Resources;
 
 namespace Wrido.Plugin.Google
 {
@@ -10,8 +9,6 @@ namespace Wrido.Plugin.Google
   {
     public void Register(ContainerBuilder builder)
     {
-      builder.RegisterResources<GooglePlugin>();
-
       builder
         .Register(GoogleHttpClient)
         .Named<HttpClient>(nameof(GoogleHttpClient))

--- a/src/Wrido.Plugin.Google/GoogleProvider.cs
+++ b/src/Wrido.Plugin.Google/GoogleProvider.cs
@@ -6,7 +6,6 @@ using System.Net.Http;
 using System.Threading;
 using System.Threading.Tasks;
 using Newtonsoft.Json.Linq;
-using Wrido.Core.Queries;
 using Wrido.Logging;
 using Wrido.Queries;
 

--- a/src/Wrido.Plugin.Google/GoogleResult.cs
+++ b/src/Wrido.Plugin.Google/GoogleResult.cs
@@ -7,7 +7,7 @@ namespace Wrido.Plugin.Google
 {
   public class GoogleResult : WebResult
   {
-    private static readonly ImageResource Logo = new ImageResource
+    private static readonly ImageResource googleLogo = new ImageResource
     {
       Uri = new Uri("/resources/wrido/plugin/google/resources/google.png", UriKind.Relative),
       Alt = "Google",
@@ -19,7 +19,7 @@ namespace Wrido.Plugin.Google
       Title = "Open Google in browser",
       Description = "https://www.google.com",
       Uri = new Uri("https://www.google.com"),
-      Resources = new []{ Logo }
+      Image = googleLogo
     };
 
     public static GoogleResult SearchResult(string query)
@@ -30,7 +30,7 @@ namespace Wrido.Plugin.Google
         Title = $"Search Google for '{query}'",
         Description = googleUrl.AbsoluteUri,
         Uri = googleUrl,
-        Resources = new[] { Logo }
+        Image = googleLogo
       };
     }
   }

--- a/src/Wrido.Plugin.Google/GoogleResult.cs
+++ b/src/Wrido.Plugin.Google/GoogleResult.cs
@@ -7,11 +7,10 @@ namespace Wrido.Plugin.Google
 {
   public class GoogleResult : WebResult
   {
-    private static readonly ImageResource googleLogo = new ImageResource
+    private static readonly Image googleLogo = new Image
     {
       Uri = new Uri("/resources/wrido/plugin/google/resources/google.png", UriKind.Relative),
       Alt = "Google",
-      Key = ResourceKeys.Icon
     };
 
     public static GoogleResult Fallback => new GoogleResult
@@ -19,7 +18,7 @@ namespace Wrido.Plugin.Google
       Title = "Open Google in browser",
       Description = "https://www.google.com",
       Uri = new Uri("https://www.google.com"),
-      Image = googleLogo
+      Icon = googleLogo
     };
 
     public static GoogleResult SearchResult(string query)
@@ -30,7 +29,7 @@ namespace Wrido.Plugin.Google
         Title = $"Search Google for '{query}'",
         Description = googleUrl.AbsoluteUri,
         Uri = googleUrl,
-        Image = googleLogo
+        Icon = googleLogo
       };
     }
   }

--- a/src/Wrido.Plugin.StackExchange.Tests/QueryParserTests.cs
+++ b/src/Wrido.Plugin.StackExchange.Tests/QueryParserTests.cs
@@ -1,6 +1,5 @@
 ﻿using System;
 using System.Linq;
-using Wrido.Core.Queries;
 using Wrido.Plugin.StackExchange.Common;
 using Wrido.Queries;
 using Xunit;

--- a/src/Wrido.Plugin.StackExchange.Tests/StackOverflowProviderTests.cs
+++ b/src/Wrido.Plugin.StackExchange.Tests/StackOverflowProviderTests.cs
@@ -3,7 +3,6 @@ using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
 using NSubstitute;
-using Wrido.Core.Queries;
 using Wrido.Plugin.StackExchange.Common;
 using Wrido.Plugin.StackExchange.StackOverflow;
 using Wrido.Queries;

--- a/src/Wrido.Plugin.StackExchange/AskUbuntu/AskUbuntuProvider.cs
+++ b/src/Wrido.Plugin.StackExchange/AskUbuntu/AskUbuntuProvider.cs
@@ -21,8 +21,6 @@ namespace Wrido.Plugin.StackExchange.AskUbuntu
         Title = $"Search Ask Ubuntu for '{query.InTitle}'",
         Uri = url,
         Description = url.ToString(),
-        Distance = 0,
-        Score = 0
       };
     }
   }

--- a/src/Wrido.Plugin.StackExchange/StackExchangePlugin.cs
+++ b/src/Wrido.Plugin.StackExchange/StackExchangePlugin.cs
@@ -7,7 +7,6 @@ using Autofac.Core;
 using Newtonsoft.Json;
 using Newtonsoft.Json.Serialization;
 using Wrido.Configuration;
-using Wrido.Core.Queries;
 using Wrido.Plugin.StackExchange.AskUbuntu;
 using Wrido.Plugin.StackExchange.Common;
 using Wrido.Plugin.StackExchange.StackOverflow;

--- a/src/Wrido.Plugin.StackExchange/StackExchangeProvider.cs
+++ b/src/Wrido.Plugin.StackExchange/StackExchangeProvider.cs
@@ -4,7 +4,6 @@ using System.Diagnostics;
 using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
-using Wrido.Core.Queries;
 using Wrido.Plugin.StackExchange.Common;
 using Wrido.Queries;
 using IQueryProvider = Wrido.Queries.IQueryProvider;

--- a/src/Wrido.Plugin.StackExchange/StackExchangeResult.cs
+++ b/src/Wrido.Plugin.StackExchange/StackExchangeResult.cs
@@ -1,12 +1,9 @@
 ﻿using System;
-using Wrido.Core.Queries;
+using Wrido.Queries;
 
 namespace Wrido.Plugin.StackExchange
 {
-  public abstract class StackExchangeResult : QueryResult
+  public abstract class StackExchangeResult : WebResult
   {
-    public Uri Uri { get; internal set; }
-    public float Distance { get; internal set; }
-    public float Score { get; internal set; }
   }
 }

--- a/src/Wrido.Plugin.StackExchange/StackOverflow/StackOverflowProvider.cs
+++ b/src/Wrido.Plugin.StackExchange/StackOverflow/StackOverflowProvider.cs
@@ -1,6 +1,5 @@
 ﻿using System;
 using System.Collections.Generic;
-using Wrido.Core.Queries;
 using Wrido.Plugin.StackExchange.Common;
 using Wrido.Queries;
 
@@ -23,8 +22,6 @@ namespace Wrido.Plugin.StackExchange.StackOverflow
                 Title = $"Search StackOverflow for '{query.InTitle}'",
                 Uri = url,
                 Description = url.ToString(),
-                Distance = 0,
-                Score = 0
             };
         }
     }

--- a/src/Wrido.Plugin.Wikipedia/WikipediaPlugin.cs
+++ b/src/Wrido.Plugin.Wikipedia/WikipediaPlugin.cs
@@ -1,7 +1,6 @@
 ﻿using System.Net.Http;
 using Autofac;
 using Newtonsoft.Json;
-using Wrido.Logging;
 using Wrido.Resources;
 
 namespace Wrido.Plugin.Wikipedia
@@ -18,9 +17,6 @@ namespace Wrido.Plugin.Wikipedia
         .RegisterType<WikipediaProvider>()
         .AsImplementedInterfaces()
         .SingleInstance();
-
-      builder
-        .RegisterResources<WikipediaPlugin>();
 
       builder
         .RegisterType<WikipediaResponseConverter>()

--- a/src/Wrido.Plugin.Wikipedia/WikipediaProvider.cs
+++ b/src/Wrido.Plugin.Wikipedia/WikipediaProvider.cs
@@ -8,7 +8,6 @@ using System.Threading;
 using System.Threading.Tasks;
 using Newtonsoft.Json;
 using Wrido.Configuration;
-using Wrido.Core.Queries;
 using Wrido.Logging;
 using Wrido.Queries;
 using IQueryProvider = Wrido.Queries.IQueryProvider;

--- a/src/Wrido.Plugin.Wikipedia/WikipediaResult.cs
+++ b/src/Wrido.Plugin.Wikipedia/WikipediaResult.cs
@@ -8,11 +8,10 @@ namespace Wrido.Plugin.Wikipedia
 {
   public class WikipediaResult : WebResult
   {
-    private static readonly ImageResource wikiLogo = new ImageResource
+    private static readonly Image wikiLogo = new Image
     {
       Uri = new Uri("/resources/wrido/plugin/wikipedia/resources/wikipedia.png", UriKind.Relative),
       Alt = "Google",
-      Key = ResourceKeys.Icon
     };
 
     public static IEnumerable<WikipediaResult> Create(WikipediaResponse response)
@@ -24,7 +23,7 @@ namespace Wrido.Plugin.Wikipedia
           Title = suggestion.Title,
           Description = suggestion.Description,
           Uri = suggestion.Uri,
-          Image = wikiLogo
+          Icon = wikiLogo
         };
       }
     }
@@ -37,7 +36,7 @@ namespace Wrido.Plugin.Wikipedia
           Title = "Open Wikipedia in browser",
           Description = url,
           Uri = new Uri(url),
-          Image = wikiLogo
+          Icon = wikiLogo
         });
     }
 
@@ -49,7 +48,7 @@ namespace Wrido.Plugin.Wikipedia
           Title = $"Search Wikipedia for '{term}'.",
           Description = $"{url}/wiki/{term}",
           Uri = new Uri(url),
-          Image = wikiLogo
+          Icon = wikiLogo
         });
     }
   }

--- a/src/Wrido.Plugin.Wikipedia/WikipediaResult.cs
+++ b/src/Wrido.Plugin.Wikipedia/WikipediaResult.cs
@@ -8,7 +8,7 @@ namespace Wrido.Plugin.Wikipedia
 {
   public class WikipediaResult : WebResult
   {
-    private static readonly ImageResource Logo = new ImageResource
+    private static readonly ImageResource wikiLogo = new ImageResource
     {
       Uri = new Uri("/resources/wrido/plugin/wikipedia/resources/wikipedia.png", UriKind.Relative),
       Alt = "Google",
@@ -24,7 +24,7 @@ namespace Wrido.Plugin.Wikipedia
           Title = suggestion.Title,
           Description = suggestion.Description,
           Uri = suggestion.Uri,
-          Resources = new[] {Logo}
+          Image = wikiLogo
         };
       }
     }
@@ -37,7 +37,7 @@ namespace Wrido.Plugin.Wikipedia
           Title = "Open Wikipedia in browser",
           Description = url,
           Uri = new Uri(url),
-          Resources = new[] {Logo}
+          Image = wikiLogo
         });
     }
 
@@ -49,7 +49,7 @@ namespace Wrido.Plugin.Wikipedia
           Title = $"Search Wikipedia for '{term}'.",
           Description = $"{url}/wiki/{term}",
           Uri = new Uri(url),
-          Resources = new[] { Logo }
+          Image = wikiLogo
         });
     }
   }

--- a/src/Wrido/Messages/QueryCompleted.cs
+++ b/src/Wrido/Messages/QueryCompleted.cs
@@ -1,7 +1,7 @@
 ﻿using System;
 using System.Collections.Generic;
 using System.Linq;
-using Wrido.Core.Queries;
+using Wrido.Queries;
 
 namespace Wrido.Messages
 {

--- a/src/Wrido/Messages/QueryReceived.cs
+++ b/src/Wrido/Messages/QueryReceived.cs
@@ -1,5 +1,4 @@
-﻿using Wrido.Core.Queries;
-using Wrido.Queries;
+﻿using Wrido.Queries;
 
 namespace Wrido.Messages
 {

--- a/src/Wrido/Messages/ResultsAvailable.cs
+++ b/src/Wrido/Messages/ResultsAvailable.cs
@@ -1,7 +1,7 @@
 ﻿using System;
 using System.Collections.Generic;
 using System.Linq;
-using Wrido.Core.Queries;
+using Wrido.Queries;
 
 namespace Wrido.Messages
 {

--- a/src/Wrido/Plugin/PluginServiceProvider.cs
+++ b/src/Wrido/Plugin/PluginServiceProvider.cs
@@ -4,6 +4,7 @@ using System.Linq;
 using Autofac;
 using Wrido.Configuration;
 using Wrido.Logging;
+using Wrido.Resources;
 
 namespace Wrido.Plugin
 {
@@ -58,6 +59,7 @@ namespace Wrido.Plugin
               _pluginScopes.Add(_rootPluginContainer.BeginLifetimeScope(pluginName, b =>
               {
                 plugin.Register(b);
+                b.RegisterResources(plugin);
                 b.RegisterModule<LoggingModule>();
               }));
               break;

--- a/src/Wrido/Queries/ExecutionService.cs
+++ b/src/Wrido/Queries/ExecutionService.cs
@@ -3,7 +3,6 @@ using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
 using Microsoft.AspNetCore.SignalR;
-using Wrido.Core.Queries;
 using Wrido.Messages;
 
 namespace Wrido.Queries

--- a/src/Wrido/Queries/QueryHub.cs
+++ b/src/Wrido/Queries/QueryHub.cs
@@ -2,7 +2,6 @@
 using System.Threading.Tasks;
 using Microsoft.AspNetCore.SignalR;
 using Serilog;
-using Wrido.Core.Queries;
 using Wrido.Logging;
 using ILogger = Wrido.Logging.ILogger;
 

--- a/src/Wrido/Resources/ResourceController.cs
+++ b/src/Wrido/Resources/ResourceController.cs
@@ -25,7 +25,13 @@ namespace Wrido.Resources
         return NotFound();
       }
       var resource = _resources[resourcePath];
-      return File(resource.Data, resource.ContentType);
+
+      if (_contentTypeProvider.TryGetContentType(resourcePath, out var contentType))
+      {
+        return File(resource.Data, contentType);
+      }
+
+      return File(resource.Data, "text/plain");
     }
 
     [HttpGet("preview/{*filePath}")]

--- a/src/Wrido/Resources/ResourceController.cs
+++ b/src/Wrido/Resources/ResourceController.cs
@@ -1,8 +1,11 @@
 ﻿using System;
+using System.Binary;
 using System.Collections.Generic;
 using System.Linq;
+using System.Text;
 using Microsoft.AspNetCore.Mvc;
 using Microsoft.AspNetCore.StaticFiles;
+using Quobject.EngineIoClientDotNet.Modules;
 
 namespace Wrido.Resources
 {
@@ -28,6 +31,15 @@ namespace Wrido.Resources
 
       if (_contentTypeProvider.TryGetContentType(resourcePath, out var contentType))
       {
+
+        // temp fix to remove null character
+        if (contentType.EndsWith("script"))
+        {
+          var dataAsString = Encoding.UTF8.GetString(resource.Data).Replace("\0", string.Empty);
+          var dataAsBytes = Encoding.UTF8.GetBytes(dataAsString);
+          return File(dataAsBytes, contentType);
+        }
+
         return File(resource.Data, contentType);
       }
 

--- a/src/Wrido/wwwroot/script/index.js
+++ b/src/Wrido/wwwroot/script/index.js
@@ -45,11 +45,14 @@ connection.start().then(() => {
             let li = document.createElement('li');
             let result = msg.results.$values[i];
 
-            if (result.image) {
+            if (result.icon) {
                 let img = document.createElement('img');
-                img.alt = result.image.alt;
-                img.src = result.image.uri;
+                img.alt = result.icon.alt;
+                img.src = result.icon.uri;
                 li.appendChild(img);
+            }
+            if (result.renderer) {
+                console.log('Recieved renderer', result.renderer);
             }
             var span = document.createElement('span');
             span.innerHTML = `${result.title} <em>(${result.description})</em>`;

--- a/src/Wrido/wwwroot/script/index.js
+++ b/src/Wrido/wwwroot/script/index.js
@@ -45,10 +45,10 @@ connection.start().then(() => {
             let li = document.createElement('li');
             let result = msg.results.$values[i];
 
-            if (result.resources && result.resources.$values.length != 0) {
+            if (result.image) {
                 let img = document.createElement('img');
-                img.alt = result.resources.$values[0].alt;
-                img.src = result.resources.$values[0].uri;
+                img.alt = result.image.alt;
+                img.src = result.image.uri;
                 li.appendChild(img);
             }
             var span = document.createElement('span');


### PR DESCRIPTION
This PR removes the generic `resources` array from the query result and replaces it with typed resources `icon` and `renderer`.

```json
{
  "title": "[Fast Provider][0]: o",
  "description": "Delayed with 249.0897 ms.",
  "icon": {
    "uri": "\/resources\/wrido\/plugin\/dummy\/resources\/phone.png",
    "alt": "Fast Provider"
  },
  "renderer": {
    "uri": "\/resources\/wrido\/plugin\/dummy\/resources\/render.js"
  }
}
```

The plugin renderer is defined in the plugin assembly as an embedded resource. I got some weird [null chars](https://en.wikipedia.org/wiki/Null_character) when loading the script from the assembly, so I had to add a temporary fix in the resource controller.

![image](https://user-images.githubusercontent.com/1032755/35608429-762c8da4-0659-11e8-9f40-e1b4b8d93626.png)
