### PR TITLE
Publish all messages on 'event'

### DIFF
--- a/src/Wrido/Messages/ExecutionCompleted.cs
+++ b/src/Wrido/Messages/ExecutionCompleted.cs
@@ -1,6 +1,6 @@
 ﻿namespace Wrido.Messages
 {
-    public class ExecutionCompleted
+    public class ExecutionCompleted : MessageBase
     {
     }
 }

--- a/src/Wrido/Messages/ExecutionFailed.cs
+++ b/src/Wrido/Messages/ExecutionFailed.cs
@@ -2,7 +2,7 @@
 
 namespace Wrido.Messages
 {
-  public class ExecutionFailed
+  public class ExecutionFailed : MessageBase
   {
     public Guid Id { get; set; }
     public string Reason { get; set; }

--- a/src/Wrido/Messages/MessageBase.cs
+++ b/src/Wrido/Messages/MessageBase.cs
@@ -2,5 +2,11 @@
 {
     public abstract class MessageBase
     {
+      protected MessageBase()
+      {
+        Type = GetType().Name;
+      }
+
+      public string Type { get; }
     }
 }

--- a/src/Wrido/Messages/QueryCancelled.cs
+++ b/src/Wrido/Messages/QueryCancelled.cs
@@ -2,7 +2,7 @@
 
 namespace Wrido.Messages
 {
-  public class QueryCancelled
+  public class QueryCancelled : MessageBase
   {
     public QueryCancelled(Guid queryId)
     {

--- a/src/Wrido/Messages/QueryCompleted.cs
+++ b/src/Wrido/Messages/QueryCompleted.cs
@@ -5,7 +5,7 @@ using Wrido.Queries;
 
 namespace Wrido.Messages
 {
-  public sealed class QueryCompleted
+  public sealed class QueryCompleted : MessageBase
   {
     public QueryCompleted(Guid queryId, IEnumerable<QueryResult> results)
     {

--- a/src/Wrido/Messages/QueryExecuting.cs
+++ b/src/Wrido/Messages/QueryExecuting.cs
@@ -4,7 +4,7 @@ using IQueryProvider = Wrido.Queries.IQueryProvider;
 
 namespace Wrido.Messages
 {
-  public class QueryExecuting
+  public class QueryExecuting : MessageBase
   {
     public IList<string> Providers { get; set; }
 

--- a/src/Wrido/Messages/QueryReceived.cs
+++ b/src/Wrido/Messages/QueryReceived.cs
@@ -2,7 +2,7 @@
 
 namespace Wrido.Messages
 {
-  public class QueryReceived
+  public class QueryReceived : MessageBase
   {
     public Query Current { get; }
 

--- a/src/Wrido/Messages/ResultsAvailable.cs
+++ b/src/Wrido/Messages/ResultsAvailable.cs
@@ -5,7 +5,7 @@ using Wrido.Queries;
 
 namespace Wrido.Messages
 {
-    public class ResultsAvailable
+    public class ResultsAvailable : MessageBase
     {
       public ResultsAvailable(Guid queryId, IEnumerable<QueryResult> results)
       {

--- a/src/Wrido/Queries/ClientProxyExtensions.cs
+++ b/src/Wrido/Queries/ClientProxyExtensions.cs
@@ -1,16 +1,26 @@
 ﻿using System.Threading;
 using System.Threading.Tasks;
 using Microsoft.AspNetCore.SignalR;
+using Wrido.Messages;
 
 namespace Wrido.Queries
 {
   public static class ClientProxyExtensions
   {
-    public static Task InvokeAsync<TMessage>(this IClientProxy client, TMessage message, CancellationToken ct = default) where TMessage : class
+    private const string _eventMethod = "event";
+
+    public static Task InvokeAsync<TMessage>(this IClientProxy client, TMessage message, CancellationToken ct = default) where TMessage : MessageBase
     {
-      return message == null
-        ? Task.FromCanceled(ct)
-        : client.InvokeAsync(typeof(TMessage).Name, message);
+      if (message == null)
+      {
+        return Task.FromCanceled(ct);
+      }
+      return Task.WhenAll(
+        client.InvokeAsync(_eventMethod, message),
+
+        // TODO: remove this call when front end uses on 'event'
+        client.InvokeAsync(typeof(TMessage).Name, message)
+      );
     }
   }
 }


### PR DESCRIPTION
This PR takes #18 a bit over half way. That is, all messages/events are published on the `event` channel, making it possible to subscribe to these in front by code similar to this

```js
connection.on('event', msg => {
    switch (msg.type) {
        case queryReceived:
            onQueryReceived(msg);
            break;
        case queryExecuting:
            console.debug('query executing');
            break;
        case resultsAvailable:
            onResultsAvailable(msg);
            break;
        case queryCompleted:
            onQueryComplete(msg);
            break;
        default:
            console.log('message not handled', msg);
    }
});
```
_However_, the event `type` is still in title case. We can/should register a separate issue that addresses this in the serialization.

In order to be compatible with the current implementation of `Wrido.Web`, messages are also published the old way, too. This can be removed once the front end is updated.