### PR TITLE
Enriching wikipedia result with more info

### DIFF
--- a/src/Wrido.Core/Logging/LogManager.cs
+++ b/src/Wrido.Core/Logging/LogManager.cs
@@ -1,0 +1,26 @@
+﻿using System;
+using System.Runtime.CompilerServices;
+
+[assembly: InternalsVisibleTo("Wrido")]
+
+namespace Wrido.Logging
+{
+  public class LogManager
+  {
+    internal static Func<Type, ILogger> LoggerFactory;
+    private static readonly SilentLogger Silent = new SilentLogger();
+
+    public static ILogger GetLogger<TLogger>()
+    {
+      return LoggerFactory?.Invoke(typeof(TLogger)) ?? Silent;
+    }
+
+    private class SilentLogger : ILogger, IDisposable
+    {
+      public void Write(LogLevel level, Exception exception, string messageTemplate, params object[] propertyValues) { }
+      public IDisposable BeginScope(string name, object value) => this;
+      public bool IsEnabled(LogLevel level) => false;
+      public void Dispose() { }
+    }
+  }
+}

--- a/src/Wrido.Core/Queries/QueryEventObserverExtensions.cs
+++ b/src/Wrido.Core/Queries/QueryEventObserverExtensions.cs
@@ -1,0 +1,18 @@
+﻿using System;
+using Wrido.Queries.Events;
+
+namespace Wrido.Queries
+{
+  public static class QueryEventObserverExtensions
+  {
+    public static void ResultAvailable(this IObserver<QueryEvent> observer, QueryResult result)
+    {
+      observer?.OnNext(new ResultAvailable(result));
+    }
+
+    public static void ResultUpdated(this IObserver<QueryEvent> observer, QueryResult result)
+    {
+      observer?.OnNext(new ResultUpdated(result));
+    }
+  }
+}

--- a/src/Wrido.Plugin.Wikipedia/Common/PageResult.cs
+++ b/src/Wrido.Plugin.Wikipedia/Common/PageResult.cs
@@ -1,0 +1,29 @@
+﻿using System;
+using System.Collections.Generic;
+
+namespace Wrido.Plugin.Wikipedia.Common
+{
+  public class PageResult
+  {
+    public long PageId { get; set; }
+    public string Title { get; set; }
+    public Image Original { get; set; }
+    public string Extract { get; set; }
+    public Dictionary<DateTime, long?> PageViews { get; set; }
+    public PageTerms Terms { get; set; }
+
+    public class PageTerms
+    {
+      public List<string> Description { get; set; }
+      public List<string> Label { get; set; }
+      public List<string> Alias { get; set; }
+    }
+
+    public class Image
+    {
+      public Uri Source { get; set; }
+      public int Width { get; set; }
+      public int Height { get; set; }
+    }
+  }
+}

--- a/src/Wrido.Plugin.Wikipedia/Common/SearchResult.cs
+++ b/src/Wrido.Plugin.Wikipedia/Common/SearchResult.cs
@@ -1,14 +1,14 @@
 ﻿using System;
 using System.Collections.Generic;
 
-namespace Wrido.Plugin.Wikipedia
+namespace Wrido.Plugin.Wikipedia.Common
 {
-  public class WikipediaResponse
+  public class SearchResult
   {
     public string Term { get; set; }
     public List<WikipediaSuggestion> Suggestions { get; set; }
 
-    public WikipediaResponse()
+    public SearchResult()
     {
       Suggestions = new List<WikipediaSuggestion>();
     }

--- a/src/Wrido.Plugin.Wikipedia/Common/WikipediaClient.cs
+++ b/src/Wrido.Plugin.Wikipedia/Common/WikipediaClient.cs
@@ -1,0 +1,113 @@
+﻿using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Net;
+using System.Net.Http;
+using System.Threading;
+using System.Threading.Tasks;
+using Newtonsoft.Json;
+using Wrido.Logging;
+
+namespace Wrido.Plugin.Wikipedia.Common
+{
+  public interface IWikipediaClient
+  {
+    Task<SearchResult> SearchAsync(string searchTerm, CancellationToken ct = default);
+    Task<PageResult> GetAsync(string pageTitle, CancellationToken ct = default);
+    Task<IEnumerable<PageResult>> GetAsync(IEnumerable<string> pageTitles, CancellationToken ct = default);
+    Uri BaseUri { get;  }
+  }
+
+  public class WikipediaClient : IWikipediaClient
+  {
+    private readonly HttpClient _httpClient;
+    private readonly JsonSerializer _serializer;
+    private const string _searchPath = "/w/api.php?action=opensearch&profile=fuzzy&limit=5&search=";
+    private const string _pagePath = "/w/api.php?action=query&prop=pageimages|extracts|pageviews|pageterms&pvipdays=1&format=json&piprop=original&exlimit=1&exintro&titles=";
+    private readonly ILogger _logger = LogManager.GetLogger<WikipediaClient>();
+    public Uri BaseUri => _httpClient.BaseAddress;
+
+    public WikipediaClient(HttpClient httpClient, JsonSerializer serializer)
+    {
+      _httpClient = httpClient;
+      _serializer = serializer;
+    }
+
+    public async Task<SearchResult> SearchAsync(string searchTerm, CancellationToken ct = default)
+    {
+      var requestUrl = $"{_searchPath}{Encode(searchTerm)}";
+      var searchResult = await GetResultAsync<SearchResult>(requestUrl, ct);
+      LoggerExtensions.Information(_logger, "The search phrase {term} resulted in {suggestionCount} suggestions.", searchResult.Term, searchResult.Suggestions.Count);
+      return searchResult;
+    }
+
+    public async Task<PageResult> GetAsync(string pageTitle, CancellationToken ct = default)
+    {
+      var resuls = await GetAsync(new[] {pageTitle}, ct);
+      return resuls.FirstOrDefault();
+    }
+
+    public async Task<IEnumerable<PageResult>> GetAsync(IEnumerable<string> pageTitles, CancellationToken ct = default)
+    {
+      var requestUrl = $"{_pagePath}{Encode(string.Join("|", pageTitles))}";
+      var batchResult = await GetResultAsync<BatchResult>(requestUrl, ct);
+      var pageResult = batchResult.Query.Pages.Values;
+      return pageResult;
+    }
+
+    private async Task<TResult> GetResultAsync<TResult>(string requestUrl, CancellationToken ct) where TResult : new()
+    {
+      HttpResponseMessage response;
+      using (_logger.Timed("Request to {requestUrl}", requestUrl))
+      {
+        response = await _httpClient.GetAsync(requestUrl, ct);
+        ct.ThrowIfCancellationRequested();
+      }
+
+      if (!response.IsSuccessStatusCode)
+      {
+        _logger.Information("Request to {requestUrl} resultet in {statusCode}, reason: {reason}",
+          requestUrl, response.StatusCode, response.ReasonPhrase);
+        return new TResult();
+      }
+
+      var jsonContent = await response.Content.ReadAsStringAsync();
+      using (var textReader = new StringReader(jsonContent))
+      using (var jsonReader = new JsonTextReader(textReader))
+      {
+        try
+        {
+          return _serializer.Deserialize<TResult>(jsonReader);
+        }
+        catch (Exception e)
+        {
+          LoggerExtensions.Error(_logger, e, "An unhandled error occured when deserializing response.");
+          return default;
+        }
+        finally
+        {
+          response.Dispose();
+        }
+      }
+    }
+
+    private static string Encode(string term)
+    {
+      return WebUtility.UrlEncode(
+        term.Replace(" ", "_")
+          .Replace("#", "♯"));
+    }
+
+    private class BatchResult
+    {
+      public string BatchComplete { get; set; }
+      public QueryResult Query { get; set; }
+
+      public class QueryResult
+      {
+        public Dictionary<long, PageResult> Pages { get; set; }
+      }
+    }
+  }
+}

--- a/src/Wrido.Plugin.Wikipedia/Serialization/WikipediaSearchConverter.cs
+++ b/src/Wrido.Plugin.Wikipedia/Serialization/WikipediaSearchConverter.cs
@@ -3,15 +3,16 @@ using System.Linq;
 using Newtonsoft.Json;
 using Newtonsoft.Json.Linq;
 using Wrido.Logging;
+using Wrido.Plugin.Wikipedia.Common;
 
-namespace Wrido.Plugin.Wikipedia
+namespace Wrido.Plugin.Wikipedia.Serialization
 {
-  public class WikipediaResponseConverter : JsonConverter
+  public class WikipediaSearchConverter : JsonConverter
   {
     private readonly ILogger _logger;
-    private static readonly Type WikiResponseType = typeof(WikipediaResponse);
+    private static readonly Type WikiResponseType = typeof(SearchResult);
 
-    public WikipediaResponseConverter(ILogger logger)
+    public WikipediaSearchConverter(ILogger logger)
     {
       _logger = logger;
     }
@@ -29,19 +30,19 @@ namespace Wrido.Plugin.Wikipedia
         var termToken = jArray?[0];
         if (termToken?.Type != JTokenType.String)
         {
-          _logger.Verbose("Expected term to be string, got {tokenType}", termToken?.Type);
+          LoggerExtensions.Verbose(_logger, "Expected term to be string, got {tokenType}", termToken?.Type);
           return null;
         }
-        var result = new WikipediaResponse
+        var result = new SearchResult
         {
           Term = termToken.Value<string>()
         };
-        _logger.Verbose("Preparing response for search term {searchTerm}", result.Term);
+        LoggerExtensions.Verbose(_logger, "Preparing response for search term {searchTerm}", result.Term);
 
         var titleArray = jArray[1];
         foreach (var titleToken in titleArray)
         {
-          result.Suggestions.Add(new WikipediaResponse.WikipediaSuggestion
+          result.Suggestions.Add(new SearchResult.WikipediaSuggestion
           {
             Title = titleToken.Value<string>()
           });
@@ -61,7 +62,7 @@ namespace Wrido.Plugin.Wikipedia
       }
       catch (Exception e)
       {
-        _logger.Warning(e, "An exception was thrown when creating the WikipediaResponse");
+        LoggerExtensions.Warning(_logger, e, "An exception was thrown when creating the SearchResult");
         return null;
       }
     }

--- a/src/Wrido.Plugin.Wikipedia/WikipediaConfiguration.cs
+++ b/src/Wrido.Plugin.Wikipedia/WikipediaConfiguration.cs
@@ -3,12 +3,12 @@ using Wrido.Configuration;
 
 namespace Wrido.Plugin.Wikipedia
 {
-  public class WikipediaPluginConfiguration : IPluginConfiguration
+  public class WikipediaConfiguration : IPluginConfiguration
   {
     public IList<string> BaseUrls { get; set; }
     public string Keyword { get; set; }
 
-    public static WikipediaPluginConfiguration Fallback = new WikipediaPluginConfiguration
+    public static WikipediaConfiguration Fallback = new WikipediaConfiguration
     {
       Keyword = ":wiki",
       BaseUrls = new List<string>

--- a/src/Wrido.Plugin.Wikipedia/WikipediaProvider.cs
+++ b/src/Wrido.Plugin.Wikipedia/WikipediaProvider.cs
@@ -1,34 +1,29 @@
 ﻿using System;
 using System.Collections.Generic;
-using System.IO;
 using System.Linq;
 using System.Net;
-using System.Net.Http;
 using System.Threading;
 using System.Threading.Tasks;
-using Newtonsoft.Json;
-using Wrido.Configuration;
 using Wrido.Logging;
+using Wrido.Plugin.Wikipedia.Common;
 using Wrido.Queries;
 using Wrido.Queries.Events;
+using Wrido.Resources;
 using IQueryProvider = Wrido.Queries.IQueryProvider;
 
 namespace Wrido.Plugin.Wikipedia
 {
   public class WikipediaProvider : IQueryProvider
   {
-    private readonly HttpClient _httpClient;
-    private readonly JsonSerializer _serializer;
+    private readonly IEnumerable<IWikipediaClient> _clients;
     private readonly ILogger _logger;
-    private readonly WikipediaPluginConfiguration _config;
-    private const string CommonUrlPath = "/w/api.php?action=opensearch&profile=fuzzy&limit=5&search=";
+    private readonly WikipediaConfiguration _config;
 
-    public WikipediaProvider(IConfigurationProvider configProvider, HttpClient httpClient, JsonSerializer serializer, ILogger logger)
+    public WikipediaProvider(IEnumerable<IWikipediaClient> clients, WikipediaConfiguration config, ILogger logger)
     {
-      _httpClient = httpClient;
-      _serializer = serializer;
+      _clients = clients;
       _logger = logger;
-      _config = configProvider.GetConfiguration<WikipediaPluginConfiguration>() ?? WikipediaPluginConfiguration.Fallback;
+      _config = config;
     }
 
     public bool CanHandle(Query query)
@@ -42,61 +37,56 @@ namespace Wrido.Plugin.Wikipedia
       {
         foreach (var fallback in WikipediaResult.CreateFallback(_config.BaseUrls))
         {
-          observer.OnNext(new ResultAvailable(fallback));
+          observer.ResultAvailable(fallback);
         }
         return;
       }
 
-      var queryTasks = _config.BaseUrls
-        .Select(url => QueryWikipediaAsync(url, query.Argument, ct))
+      var queryTasks = _clients
+        .Select(client => QueryWikipediaAsync(client, query.Argument, observer, ct))
         .ToList();
       await Task.WhenAll(queryTasks);
 
-      var results = queryTasks.SelectMany(q => q.Result).ToList();
+      var results = queryTasks.SelectMany(q => q.Result.Suggestions).ToList();
       if (!results.Any())
       {
         foreach (var searchResult in WikipediaResult.CreateSearch(Encode(query.Argument), _config.BaseUrls))
         {
-          observer.OnNext(new ResultAvailable(searchResult));
+          observer.ResultAvailable(searchResult);
         }
-      }
-      foreach (var queryResult in results)
-      {
-        observer.OnNext(new ResultAvailable(queryResult));
       }
     }
 
-    private async Task<IEnumerable<QueryResult>> QueryWikipediaAsync(string baseUrl, string searchTerm, CancellationToken ct)
+    private async Task<SearchResult> QueryWikipediaAsync(IWikipediaClient client, string searchTerm, IObserver<QueryEvent> observer, CancellationToken ct)
     {
-      var requestUrl = $"{baseUrl}{CommonUrlPath}{Encode(searchTerm)}";
-      var response = await _httpClient.GetAsync(requestUrl, ct);
-      ct.ThrowIfCancellationRequested();
+      var searchResult = await client.SearchAsync(searchTerm, ct);
+      _logger.Information("The search phrase {term} resulted in {suggestionCount} suggestions.", searchResult.Term, searchResult.Suggestions.Count);
+      var results = WikipediaResult.Create(searchResult).ToList();
 
-      if (!response.IsSuccessStatusCode)
+      foreach (var result in results)
       {
-        return Enumerable.Empty<QueryResult>();
+        _logger.Verbose("Wikipedia result {title} available", result.Title);
+        observer.ResultAvailable(result);
       }
 
-      var jsonContent = await response.Content.ReadAsStringAsync();
-      using (var textReader = new StringReader(jsonContent))
-      using (var jsonReader = new JsonTextReader(textReader))
+      var pageTitles = results.Select(r => r.Title);
+      var pages = await client.GetAsync(pageTitles, ct);
+      var pagesByTitle = pages.ToDictionary(page => page.Title, page => page);
+      foreach (var result in results)
       {
-        try
+        if (!pagesByTitle.ContainsKey(result.Title))
         {
-          var wikiRespose = _serializer.Deserialize<WikipediaResponse>(jsonReader);
-          _logger.Information("The search phrase {term} resulted in {suggestionCount} suggestions.", wikiRespose.Term, wikiRespose.Suggestions.Count);
-          return WikipediaResult.Create(wikiRespose);
+          _logger.Warning("Unable to find {pageTitle} in title dictionary", result.Title);
+          continue;
         }
-        catch (Exception e)
-        {
-          _logger.Error(e, "An unhandled error occured when deserializing response.");
-          throw;
-        }
-        finally
-        {
-          response.Dispose();
-        }
+        _logger.Verbose("Page {pageTitle} found. Enriching result", result.Title);
+        var pageResult = pagesByTitle[result.Title];
+        result.Extract = pageResult.Extract;
+        result.PageImage = new Image { Uri = pageResult.Original?.Source, Alt = result.Title};
+        result.Views = pageResult.PageViews.Values.FirstOrDefault() ?? 0;
+        observer.ResultUpdated(result);
       }
+      return searchResult;
     }
 
     private static string Encode(string term)

--- a/src/Wrido.Plugin.Wikipedia/WikipediaResult.cs
+++ b/src/Wrido.Plugin.Wikipedia/WikipediaResult.cs
@@ -1,6 +1,7 @@
 ﻿using System;
 using System.Collections.Generic;
 using System.Linq;
+using Wrido.Plugin.Wikipedia.Common;
 using Wrido.Queries;
 using Wrido.Resources;
 
@@ -8,22 +9,26 @@ namespace Wrido.Plugin.Wikipedia
 {
   public class WikipediaResult : WebResult
   {
-    private static readonly Image wikiLogo = new Image
+    private static readonly Image _wikiLogo = new Image
     {
       Uri = new Uri("/resources/wrido/plugin/wikipedia/resources/wikipedia.png", UriKind.Relative),
-      Alt = "Google",
+      Alt = "Wikipedia"
     };
 
-    public static IEnumerable<WikipediaResult> Create(WikipediaResponse response)
+    public string Extract { get; set; }
+    public Image PageImage { get; set; }
+    public long Views { get; set; }
+
+    public static IEnumerable<WikipediaResult> Create(SearchResult result)
     {
-      foreach (var suggestion in response.Suggestions)
+      foreach (var suggestion in result.Suggestions)
       {
         yield return new WikipediaResult
         {
           Title = suggestion.Title,
           Description = suggestion.Description,
           Uri = suggestion.Uri,
-          Icon = wikiLogo
+          Icon = _wikiLogo
         };
       }
     }
@@ -36,7 +41,7 @@ namespace Wrido.Plugin.Wikipedia
           Title = "Open Wikipedia in browser",
           Description = url,
           Uri = new Uri(url),
-          Icon = wikiLogo
+          Icon = _wikiLogo
         });
     }
 
@@ -48,7 +53,7 @@ namespace Wrido.Plugin.Wikipedia
           Title = $"Search Wikipedia for '{term}'.",
           Description = $"{url}/wiki/{term}",
           Uri = new Uri(url),
-          Icon = wikiLogo
+          Icon = _wikiLogo
         });
     }
   }

--- a/src/Wrido.Plugin.Wikipedia/Wrido.Plugin.Wikipedia.csproj
+++ b/src/Wrido.Plugin.Wikipedia/Wrido.Plugin.Wikipedia.csproj
@@ -4,6 +4,14 @@
     <TargetFramework>netstandard2.0</TargetFramework>
   </PropertyGroup>
 
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|AnyCPU'">
+    <LangVersion>7.1</LangVersion>
+  </PropertyGroup>
+
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|AnyCPU'">
+    <LangVersion>7.1</LangVersion>
+  </PropertyGroup>
+
   <ItemGroup>
     <None Remove="Resources\Wikipedia.png" />
   </ItemGroup>

--- a/src/Wrido.Plugin.Wikipedia/Wrido.Plugin.Wikipedia.csproj.DotSettings
+++ b/src/Wrido.Plugin.Wikipedia/Wrido.Plugin.Wikipedia.csproj.DotSettings
@@ -1,0 +1,2 @@
+﻿<wpf:ResourceDictionary xml:space="preserve" xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml" xmlns:s="clr-namespace:System;assembly=mscorlib" xmlns:ss="urn:shemas-jetbrains-com:settings-storage-xaml" xmlns:wpf="http://schemas.microsoft.com/winfx/2006/xaml/presentation">
+	<s:String x:Key="/Default/CodeInspection/CSharpLanguageProject/LanguageLevel/@EntryValue">CSharp71</s:String></wpf:ResourceDictionary>

--- a/src/Wrido/Program.cs
+++ b/src/Wrido/Program.cs
@@ -30,6 +30,7 @@ namespace Wrido
         .Enrich.FromLogContext()
         .WriteTo.Console(outputTemplate: LogTemplates.Console)
         .CreateLogger();
+      LogManager.LoggerFactory = type => new SerilogLogger(Log.ForContext(type));
 
       Log.Information("Application started with {applicationArgs}", args);
 


### PR DESCRIPTION
This PR adds the backend parts of #27 by enriching the wikipedia results with more properties:

* `extract`, the first paragraph of the wiki article, formatted as html.
* `views` number of page views today
* `pageImage`, an image resource connected to the article

The result will be updated (`ResultUpdated`) once the the data is available. Example payload:

```json
{
  "result": {
    "extract": null,
    "pageImage": {
      "uri": "https://upload.wikimedia.org/wikipedia/commons/5/55/Apollo_11_lunar_module_%28cropped%29.jpg",
      "alt": "NASA spinoff technologies"
    },
    "views": 245,
    "uri": "https://en.wikipedia.org/wiki/NASA_spinoff_technologies",
    "id": "a98075e9-f21b-4752-9aec-d01b2ff7a71f",
    "title": "NASA spinoff technologies",
    "description": "NASA spinoff technologies are commercial products and services which have been developed with the help of NASA, through research and development contracts, such as Small Business Innovation Research (SBIR) or STTR awards, licensing of NASA patents, use of NASA facilities, technical assistance from NASA personnel, or data from NASA research.",
    "icon": {
      "uri": "/resources/wrido/plugin/wikipedia/resources/wikipedia.png",
      "alt": "Wikipedia"
    },
    "renderer": null
  },
  "type": "ResultAvailable"
}
```