### PR TITLE
Add capabilities to load plugins from nuget

### DIFF
--- a/src/Wrido.Core/Configuration/AppConfiguration.cs
+++ b/src/Wrido.Core/Configuration/AppConfiguration.cs
@@ -1,12 +1,20 @@
-﻿namespace Wrido.Configuration
+﻿using System;
+using System.Reflection;
+
+namespace Wrido.Configuration
 {
   public interface IAppConfiguration
   {
     string HotKey { get; }
+    string ConfigurationDirectory { get; }
+    string InstallDirectory { get; }
   }
 
   internal class AppConfiguration : IAppConfiguration
   {
     public string HotKey { get; set; }
+
+    public string ConfigurationDirectory => $"{Environment.GetFolderPath(Environment.SpecialFolder.UserProfile)}\\.wrido\\";
+    public string InstallDirectory => AppDomain.CurrentDomain.BaseDirectory;
   }
 }

--- a/src/Wrido.Core/Configuration/ConfigurationProvider.cs
+++ b/src/Wrido.Core/Configuration/ConfigurationProvider.cs
@@ -106,6 +106,7 @@ namespace Wrido.Configuration
               continue;
             }
             _plugins.Add(nameToken.Value<string>(), pluginObj);
+            continue;
           }
           _logger.Warning("Unidentified plugin of type {tokenType}", plugin.Type);
         }

--- a/src/Wrido/Plugin/AssemblyPluginLoader.cs
+++ b/src/Wrido/Plugin/AssemblyPluginLoader.cs
@@ -2,6 +2,7 @@
 using System.IO;
 using System.Linq;
 using System.Reflection;
+using Wrido.Configuration;
 using Wrido.Logging;
 
 namespace Wrido.Plugin
@@ -13,13 +14,13 @@ namespace Wrido.Plugin
 
   public class AssemblyPluginLoader : IPluginLoader
   {
-    private readonly string _currentDirectory;
     private readonly ILogger _logger;
+    private readonly IAppConfiguration _config;
 
-    public AssemblyPluginLoader(ILogger logger)
+    public AssemblyPluginLoader(ILogger logger, IAppConfiguration config)
     {
       _logger = logger;
-      _currentDirectory = AppDomain.CurrentDomain.BaseDirectory;
+      _config = config;
     }
 
     public bool TryLoad(string pluginName, out IWridoPlugin plugin)
@@ -27,7 +28,7 @@ namespace Wrido.Plugin
       plugin = default;
 
       var assemblyFiles = Directory
-        .GetFiles(_currentDirectory)
+        .GetFiles(_config.InstallDirectory)
         .Where(f => f.EndsWith(".dll", StringComparison.OrdinalIgnoreCase));
 
       var exactMatch = assemblyFiles.FirstOrDefault(f => f.EndsWith($"{pluginName}.dll", StringComparison.InvariantCultureIgnoreCase));

--- a/src/Wrido/Plugin/NugetPluginLoader.cs
+++ b/src/Wrido/Plugin/NugetPluginLoader.cs
@@ -1,0 +1,124 @@
+﻿using System;
+using System.Collections.Generic;
+using System.IO;
+using System.IO.Compression;
+using System.Linq;
+using System.Net;
+using Wrido.Configuration;
+using Wrido.Logging;
+
+namespace Wrido.Plugin
+{
+  public class NugetPluginLoader : IPluginLoader
+  {
+    private readonly AssemblyPluginLoader _pluginLoder;
+    private readonly IAppConfiguration _config;
+    private readonly ILogger _logger;
+
+    public NugetPluginLoader(AssemblyPluginLoader pluginLoder, IAppConfiguration config, ILogger logger)
+    {
+      _pluginLoder = pluginLoder;
+      _config = config;
+      _logger = logger;
+    }
+
+    public bool TryLoad(string pluginName, out IWridoPlugin plugin)
+    {
+      if (!pluginName.StartsWith("wrido.plugin", StringComparison.InvariantCultureIgnoreCase))
+      {
+        _logger.Warning("{pluginName} is not a recognized plugin name", pluginName);
+        plugin = default;
+        return false;
+      }
+
+      if (_pluginLoder.TryLoad(pluginName, out plugin))
+      {
+        _logger.Verbose("Plugin {pluginName} found by assembly loader", pluginName);
+        return true;
+      }
+
+      var workingDirectory = CreateWorkingDirectory();
+      var downloaded = TryDownloadNuget(workingDirectory, pluginName, out var nugetFile);
+      if (!downloaded)
+      {
+        Directory.Delete(workingDirectory, true);
+        _logger.Warning("Unable to load plugin {pluginName}", pluginName);
+        return false;
+      }
+
+      var nugetDirectory = Path.Combine(workingDirectory, pluginName);
+      try
+      {
+        _logger.Debug("Extracting {nugetFile} to {nugetDirectory}", nugetFile, nugetDirectory);
+        ZipFile.ExtractToDirectory(nugetFile, nugetDirectory);
+      }
+      catch (Exception e)
+      {
+        Directory.Delete(workingDirectory, true);
+        _logger.Warning(e, "Unable to extract {nugetFile} to {nugetDirectory}", nugetFile, nugetDirectory);
+        return false;
+      }
+
+      var dllFiles = Directory.GetFiles(nugetDirectory, "*.dll", SearchOption.AllDirectories).ToList();
+      var pluginDllPath = FindCompatibleDll(dllFiles);
+      if (string.IsNullOrWhiteSpace(pluginDllPath))
+      {
+        Directory.Delete(workingDirectory, true);
+        _logger.Warning("Unable to find compatable version of {pluginName}", pluginName);
+        return false;
+      }
+
+      var targetDllPath = Path.Combine(_config.InstallDirectory, Path.GetFileName(pluginDllPath));
+      _logger.Debug("Copying file {pluginDllPath} to {targetDllPath}", pluginDllPath, targetDllPath);
+      File.Copy(pluginDllPath, targetDllPath);
+      Directory.Delete(workingDirectory, true);
+      return _pluginLoder.TryLoad(pluginName, out plugin);
+    }
+
+    private string FindCompatibleDll(List<string> dllPaths)
+    {
+      const string netStandard = "netstandard";
+      var compatible = dllPaths.LastOrDefault(p => p.Contains(netStandard));
+      if (!string.IsNullOrEmpty(compatible))
+      {
+        _logger.Debug("Found netstandard dll {dllPath} that is expected to be compatable", compatible);
+        return compatible;
+      }
+
+      _logger.Information("No netstandard dll found, returning first dll and hope it works");
+      return dllPaths.FirstOrDefault();
+    }
+
+    private bool TryDownloadNuget(string workingDirectory, string nugetPackageName, out string fileName)
+    {
+      var nugetUrl = $"https://www.nuget.org/api/v2/package/{nugetPackageName}";
+      fileName = Path.Combine(workingDirectory, $"{nugetPackageName}.nupkg");
+      _logger.Verbose("Setting download path to {nugetDirectory}", fileName);
+
+      using (var webClient = new WebClient())
+      {
+        try
+        {
+          using (_logger.Timed("Download package {pluginName} from NuGet", nugetPackageName))
+          {
+            webClient.DownloadFile(nugetUrl, fileName);
+          }
+        }
+        catch (Exception e)
+        {
+          _logger.Information(e, "Unable to download {pluginName} from NuGet.org", nugetPackageName);
+          return false;
+        }
+      }
+      return true;
+    }
+
+    private string CreateWorkingDirectory()
+    {
+      var workingDir = Path.Combine(_config.ConfigurationDirectory, Guid.NewGuid().ToString());
+      Directory.CreateDirectory(workingDir);
+      _logger.Debug("Working directory {workingDirectory} created.", workingDir);
+      return workingDir;
+    }
+  }
+}

--- a/src/Wrido/Plugin/PluginModule.cs
+++ b/src/Wrido/Plugin/PluginModule.cs
@@ -10,6 +10,11 @@ namespace Wrido.Plugin
     {
       builder
         .RegisterType<AssemblyPluginLoader>()
+        .AsSelf()
+        .SingleInstance();
+
+      builder
+        .RegisterType<NugetPluginLoader>()
         .AsImplementedInterfaces()
         .SingleInstance();
 


### PR DESCRIPTION
This PR closes #19 by adding a rudimentary strategy for loading plugins from nuget.org. The following assumptions are made:

* Nuget package name is the same as plugin name
* Nuget package does only contain one dll file (most well formed packages do, probably true for all plugins)

The loader prefers dlls for `netstandard` which is the tell-tell sign that they are cross platform.