### PR TITLE
Handle 'ResultAvailable' in frontend

### DIFF
--- a/src/Wrido.Core/Queries/Events/ResultAvailable.cs
+++ b/src/Wrido.Core/Queries/Events/ResultAvailable.cs
@@ -1,11 +1,16 @@
-﻿namespace Wrido.Queries.Events
+﻿using System;
+
+namespace Wrido.Queries.Events
 {
   public class ResultAvailable : QueryEvent
   {
-    public ResultAvailable(QueryResult result)
+    public QueryResult Result { get; set; }
+    public Guid QueryId { get; set; }
+
+    public ResultAvailable(QueryResult result, Guid queryId)
     {
       Result = result;
+      QueryId = queryId;
     }
-    public QueryResult Result { get; set; }
   }
 }

--- a/src/Wrido.Core/Queries/QueryEventObserverExtensions.cs
+++ b/src/Wrido.Core/Queries/QueryEventObserverExtensions.cs
@@ -5,9 +5,9 @@ namespace Wrido.Queries
 {
   public static class QueryEventObserverExtensions
   {
-    public static void ResultAvailable(this IObserver<QueryEvent> observer, QueryResult result)
+    public static void ResultAvailable(this IObserver<QueryEvent> observer, QueryResult result, Guid queryId)
     {
-      observer?.OnNext(new ResultAvailable(result));
+      observer?.OnNext(new ResultAvailable(result, queryId));
     }
 
     public static void ResultUpdated(this IObserver<QueryEvent> observer, QueryResult result)

--- a/src/Wrido.Plugin.Dummy/DummyProvider.cs
+++ b/src/Wrido.Plugin.Dummy/DummyProvider.cs
@@ -30,7 +30,7 @@ namespace Wrido.Plugin.Dummy
 
     public bool CanHandle(Query query)
     {
-      return true;
+      return !query.Command.StartsWith(":");
     }
 
     public async Task QueryAsync(Query query, IObserver<QueryEvent> observer, CancellationToken ct)
@@ -47,14 +47,14 @@ namespace Wrido.Plugin.Dummy
           Icon = _iconResource,
           Renderer = new Script("/resources/wrido/plugin/dummy/resources/render.js")
         };
-        observer.OnNext(new ResultAvailable(result));
+        observer.ResultAvailable(result, query.Id);
 
         if (_random.NextDouble() > 0.5)
         {
           await Task.Delay(duration, ct);
           result.Title = $"{result.Title} - UPDATED!";
 
-          observer.OnNext(new ResultUpdated(result));
+          observer.ResultUpdated(result);
         }
       }
     }

--- a/src/Wrido.Plugin.Google/GoogleProvider.cs
+++ b/src/Wrido.Plugin.Google/GoogleProvider.cs
@@ -33,7 +33,7 @@ namespace Wrido.Plugin.Google
       if (string.IsNullOrEmpty(query.Argument))
       {
         _logger.Verbose("No search term entered, returning fallback result.");
-        observer.OnNext(new ResultAvailable(GoogleResult.Fallback));
+        observer.ResultAvailable(GoogleResult.Fallback, query.Id);
         return;
       }
 
@@ -57,7 +57,7 @@ namespace Wrido.Plugin.Google
 
       foreach (var suggestion in suggestions)
       {
-        observer.OnNext(new ResultAvailable(GoogleResult.SearchResult(suggestion)));
+        observer.ResultAvailable(GoogleResult.SearchResult(suggestion), query.Id);
       }
     }
   }

--- a/src/Wrido.Plugin.StackExchange/StackExchangeProvider.cs
+++ b/src/Wrido.Plugin.StackExchange/StackExchangeProvider.cs
@@ -44,13 +44,13 @@ namespace Wrido.Plugin.StackExchange
       {
         foreach (var queryResult in CreateFallbackResult(searchQuery))
         {
-          observer.OnNext(new ResultAvailable(queryResult));
+          observer.ResultAvailable(queryResult, query.Id);
         }
         return;
       }
       foreach (var queryResult in questions.Select(q=> ConvertQuestion(q, query)))
       {
-        observer.OnNext(new ResultAvailable(queryResult));
+        observer.ResultAvailable(queryResult, query.Id);
       }
     }
 

--- a/src/Wrido.Web/src/actionCreators.js
+++ b/src/Wrido.Web/src/actionCreators.js
@@ -10,9 +10,8 @@ export const queryReceivedAction = createActionCreator('QueryReceived', value =>
 // This list can be used to setup toggle load state etc.
 export const queryExecutingAction = createActionCreator('QueryExecuting', value => ({ value }));
 
-// Triggered each time a query provider has completed its execution.
-// This event marks a partial completion of the query
-export const resultsAvailableAction = createActionCreator('ResultsAvailable', value => ({ value }));
+// Triggered each time a result is available.
+export const resultAvailableAction = createActionCreator('ResultAvailable', value => ({ value }));
 
 // Triggered when all applicable Query Providers have produced result.
 export const queryCompletedAction = createActionCreator('QueryCompleted', value => ({ value }));

--- a/src/Wrido.Web/src/modules/reducers.js
+++ b/src/Wrido.Web/src/modules/reducers.js
@@ -1,4 +1,4 @@
-import { onInputChangeAction, queryReceivedAction, resultsAvailableAction } from '../actionCreators';
+import { onInputChangeAction, queryReceivedAction, resultAvailableAction } from '../actionCreators';
 import { reducer } from '../reduxUtils';
 
 export const input = reducer(
@@ -16,10 +16,10 @@ export const result = reducer(
     })
   ],
   [
-    resultsAvailableAction,
+    resultAvailableAction,
     (state, action) => ({
       items: action.queryId === state.currentQueryId ?
-        state.items.concat(action.results.$values) :
+        state.items.concat([action.result]) :
         state.items
     })
   ],

--- a/src/Wrido/Properties/launchSettings.json
+++ b/src/Wrido/Properties/launchSettings.json
@@ -8,7 +8,7 @@
         "ASPNETCORE_ENVIRONMENT": "Development",
         "ELECTRON": "false"
       },
-      "applicationUrl": "http://localhost:50206/"
+      "applicationUrl": "http://localhost:5000/"
     },
 
     "Electron": {


### PR DESCRIPTION
This PR adds a new reducer for the `ResultAvailable` event, related to #23. It still doesn't leverage the streaming of events available, but at least it makes the front end render results 😉 

I also updated the default port to 5000 for the application, no matter how you run it (VS, `dotnet run` etc)