### PR TITLE
Add hot reload capability

### DIFF
--- a/src/Wrido.Core/Cache/AutofacCachingExtension.cs
+++ b/src/Wrido.Core/Cache/AutofacCachingExtension.cs
@@ -1,6 +1,7 @@
 ﻿using System;
 using System.Collections.Generic;
 using Autofac;
+using Wrido.Configuration;
 using Wrido.Queries;
 
 namespace Wrido.Cache
@@ -19,7 +20,7 @@ namespace Wrido.Cache
         .InstancePerDependency();
 
       builder
-        .Register(c => new CachingQueryProvider(c.Resolve<TProvider>(), expires, comparer))
+        .Register(c => new CachingQueryProvider(c.Resolve<TProvider>(), c.Resolve<IConfigurationProvider>(), expires, comparer))
         .AsImplementedInterfaces()
         .InstancePerDependency();
       return builder;

--- a/src/Wrido.Core/Cache/CachingProvider.cs
+++ b/src/Wrido.Core/Cache/CachingProvider.cs
@@ -3,6 +3,7 @@ using System.Collections.Concurrent;
 using System.Collections.Generic;
 using System.Threading;
 using System.Threading.Tasks;
+using Wrido.Configuration;
 using Wrido.Logging;
 using Wrido.Queries;
 using Wrido.Queries.Events;
@@ -16,11 +17,12 @@ namespace Wrido.Cache
     private readonly ILogger _logger = LogManager.GetLogger<CachingQueryProvider>();
     private static ConcurrentDictionary<string, List<QueryEvent>> _eventCache = new ConcurrentDictionary<string, List<QueryEvent>>();
 
-    public CachingQueryProvider(IQueryProvider actualProvider, TimeSpan expires, IEqualityComparer<string> comparer = default)
+    public CachingQueryProvider(IQueryProvider actualProvider, IConfigurationProvider configProvider, TimeSpan expires, IEqualityComparer<string> comparer = default)
     {
       comparer = comparer ?? StringComparer.InvariantCultureIgnoreCase;
       _actualProvider = actualProvider;
       _expires = expires;
+      configProvider.ConfigurationUpdated += (sender, args) => _eventCache.Clear();
     }
 
     public async Task QueryAsync(Query query, IObserver<QueryEvent> observer, CancellationToken ct)

--- a/src/Wrido.Core/Configuration/AppConfiguration.cs
+++ b/src/Wrido.Core/Configuration/AppConfiguration.cs
@@ -1,12 +1,11 @@
 ﻿using System;
-using System.Reflection;
 
 namespace Wrido.Configuration
 {
   public interface IAppConfiguration
   {
     string HotKey { get; }
-    string ConfigurationDirectory { get; }
+    string ConfigurationFilePath { get; }
     string InstallDirectory { get; }
   }
 
@@ -14,7 +13,13 @@ namespace Wrido.Configuration
   {
     public string HotKey { get; set; }
 
-    public string ConfigurationDirectory => $"{Environment.GetFolderPath(Environment.SpecialFolder.UserProfile)}\\.wrido\\";
-    public string InstallDirectory => AppDomain.CurrentDomain.BaseDirectory;
+    public string ConfigurationFilePath => ReadOnlyAppConfiguration.ConfigurationFilePath;
+    public string InstallDirectory => ReadOnlyAppConfiguration.InstallDirectory;
+  }
+
+  internal static class ReadOnlyAppConfiguration
+  {
+    public static string ConfigurationFilePath => $"{Environment.GetFolderPath(Environment.SpecialFolder.UserProfile)}\\herehere.json";
+    public static string InstallDirectory => AppDomain.CurrentDomain.BaseDirectory;
   }
 }

--- a/src/Wrido.Core/Configuration/ConfigurationFileWatcher.cs
+++ b/src/Wrido.Core/Configuration/ConfigurationFileWatcher.cs
@@ -1,0 +1,72 @@
+﻿using System;
+using System.IO;
+using System.Threading;
+using Wrido.Logging;
+
+namespace Wrido.Configuration
+{
+  internal interface IConfigurationFileWatcher
+  {
+    event FileSystemEventHandler Updated;
+  }
+
+  internal class ConfigurationFileWatcher : IDisposable, IConfigurationFileWatcher
+  {
+    private readonly ILogger _logger;
+    private readonly FileSystemWatcher _fileWatcher;
+    public event FileSystemEventHandler Updated;
+    private bool _eventDispatchQueued;
+    private Timer _timer;
+    private readonly object _dispatchLock = new object();
+
+    public ConfigurationFileWatcher(ILogger logger)
+    {
+      _logger = logger;
+      var cfgPath = Path.GetDirectoryName(ReadOnlyAppConfiguration.ConfigurationFilePath);
+      var cfgFileName = Path.GetFileName(ReadOnlyAppConfiguration.ConfigurationFilePath);
+      _logger.Information("Setting up file watcher on {configFileName} in {configDirectory}.", cfgFileName, cfgPath);
+      _fileWatcher = new FileSystemWatcher
+      {
+        Path = cfgPath,
+        Filter = cfgFileName,
+        EnableRaisingEvents = true,
+        IncludeSubdirectories = false,
+        NotifyFilter = NotifyFilters.LastWrite
+      };
+      _fileWatcher.Changed += ThrottleAndDispatch;
+      _fileWatcher.Created += ThrottleAndDispatch;
+    }
+
+    private void ThrottleAndDispatch(object sender, FileSystemEventArgs fileSystemEventArgs)
+    {
+      if (_eventDispatchQueued)
+      {
+        _logger.Verbose("Event dispatch is already queued.");
+        return;
+      }
+
+      if (!Monitor.TryEnter(_dispatchLock))
+      {
+        _logger.Verbose("Another thread currently holds the lock to the event dispatcher");
+        return;
+      }
+      
+      _logger.Information("Configuration file updated. Preparing to raise event.");
+      _eventDispatchQueued = true;
+
+      _timer = new Timer(state =>
+      {
+        _logger.Information("Raising file updated event.");
+        Updated?.Invoke(this, fileSystemEventArgs);
+        _eventDispatchQueued = false;
+      }, null, TimeSpan.FromMilliseconds(100), new TimeSpan(-1));
+      Monitor.Exit(_dispatchLock);
+    }
+
+    public void Dispose()
+    {
+      _fileWatcher.Dispose();
+      _timer?.Dispose();
+    }
+  }
+}

--- a/src/Wrido.Core/Configuration/ConfigurationModule.cs
+++ b/src/Wrido.Core/Configuration/ConfigurationModule.cs
@@ -1,4 +1,6 @@
-﻿using Autofac;
+﻿using System;
+using System.Collections.Generic;
+using Autofac;
 
 namespace Wrido.Configuration
 {
@@ -8,6 +10,11 @@ namespace Wrido.Configuration
     {
       builder
         .RegisterType<ConfigurationProvider>()
+        .AsImplementedInterfaces()
+        .SingleInstance();
+
+      builder
+        .RegisterType<ConfigurationFileWatcher>()
         .AsImplementedInterfaces()
         .SingleInstance();
 

--- a/src/Wrido.Core/Plugin/IWridoPlugin.cs
+++ b/src/Wrido.Core/Plugin/IWridoPlugin.cs
@@ -1,5 +1,4 @@
 ﻿using Autofac;
-using Autofac.Core;
 
 namespace Wrido.Plugin
 {

--- a/src/Wrido.Plugin.Dummy/DummyProvider.cs
+++ b/src/Wrido.Plugin.Dummy/DummyProvider.cs
@@ -29,6 +29,10 @@ namespace Wrido.Plugin.Dummy
 
     public override bool CanHandle(Query query)
     {
+      if (string.IsNullOrEmpty(query?.Raw))
+      {
+        return false;
+      }
       return !query?.Command?.StartsWith(":") ?? true;
     }
 

--- a/src/Wrido.Plugin.Wikipedia/WikipediaPlugin.cs
+++ b/src/Wrido.Plugin.Wikipedia/WikipediaPlugin.cs
@@ -36,24 +36,26 @@ namespace Wrido.Plugin.Wikipedia
           .Resolve<IConfigurationProvider>()
           .GetConfiguration<WikipediaConfiguration>() ?? WikipediaConfiguration.Fallback)
         .AsSelf()
-        .SingleInstance();
+        .InstancePerDependency();
 
       builder
         .Register(c =>
-        {
-          var pluginConfig = c.Resolve<WikipediaConfiguration>();
-          var clients = new List<IWikipediaClient>();
-          foreach (var baseUrl in pluginConfig.BaseUrls)
           {
-            var httpClient = new HttpClient
+            var pluginConfig = c.Resolve<WikipediaConfiguration>();
+            var clients = new List<IWikipediaClient>();
+            foreach (var baseUrl in pluginConfig.BaseUrls)
             {
-              BaseAddress = new Uri(baseUrl)
-            };
-            var client = new WikipediaClient(httpClient, c.Resolve<JsonSerializer>());
-            clients.Add(client);
-          }
-          return clients;
-        }).As<IEnumerable<IWikipediaClient>>().SingleInstance();
+              var httpClient = new HttpClient
+              {
+                BaseAddress = new Uri(baseUrl)
+              };
+              var client = new WikipediaClient(httpClient, c.Resolve<JsonSerializer>());
+              clients.Add(client);
+            }
+            return clients;
+          })
+        .As<IEnumerable<IWikipediaClient>>()
+        .SingleInstance();
     }
   }
 }

--- a/src/Wrido.Plugin.Wikipedia/WikipediaProvider.cs
+++ b/src/Wrido.Plugin.Wikipedia/WikipediaProvider.cs
@@ -4,6 +4,7 @@ using System.Linq;
 using System.Net;
 using System.Threading;
 using System.Threading.Tasks;
+using Wrido.Configuration;
 using Wrido.Logging;
 using Wrido.Plugin.Wikipedia.Common;
 using Wrido.Queries;

--- a/src/Wrido/Plugin/NugetPluginLoader.cs
+++ b/src/Wrido/Plugin/NugetPluginLoader.cs
@@ -115,7 +115,7 @@ namespace Wrido.Plugin
 
     private string CreateWorkingDirectory()
     {
-      var workingDir = Path.Combine(_config.ConfigurationDirectory, Guid.NewGuid().ToString());
+      var workingDir = Path.Combine(_config.InstallDirectory, Guid.NewGuid().ToString());
       Directory.CreateDirectory(workingDir);
       _logger.Debug("Working directory {workingDirectory} created.", workingDir);
       return workingDir;

--- a/src/Wrido/Startup.cs
+++ b/src/Wrido/Startup.cs
@@ -9,7 +9,6 @@ using Wrido.Configuration;
 using Wrido.Electron;
 using Wrido.Logging;
 using Wrido.Plugin;
-using Wrido.Plugin.Wikipedia;
 using Wrido.Queries;
 using Wrido.Resources;
 


### PR DESCRIPTION
This PR closes #36 by implementing a hot configuration reload. This is done by:

1. Implement a `ConfigurationFileWatcher` that raises an event when the configuration file is updated
2. Let the `ConfigurationProvider` listen to this event and reload the configuration then raise an `ConfigurationUpdated` event.
3. Let `PluginServiceProvider` listen to this event and dispose all plugin scopes and create new plugin scopes for the current list of configured dependencies.

![update-plugin-cfg](https://user-images.githubusercontent.com/1032755/36072736-1900c882-0f25-11e8-8015-543989aca8f9.gif)
![add-plugin](https://user-images.githubusercontent.com/1032755/36072737-1b7436c6-0f25-11e8-96ca-269cc1c230ed.gif)
